### PR TITLE
Add configurable image and result paths across pipeline

### DIFF
--- a/M0_Preprocess/EyeQ_process_main.py
+++ b/M0_Preprocess/EyeQ_process_main.py
@@ -3,9 +3,54 @@ import os
 import pandas as pd
 from PIL import ImageFile
 import shutil
+from argparse import ArgumentParser
+from pathlib import Path
+import tempfile
+import atexit
+
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 
-AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','..')
+DEFAULT_AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA', '..')
+
+
+def prepare_automorph_data(image_folder, result_folder):
+
+    image_path = Path(image_folder).expanduser().resolve()
+    result_path = Path(result_folder).expanduser().resolve()
+
+    image_path.mkdir(parents=True, exist_ok=True)
+    result_path.mkdir(parents=True, exist_ok=True)
+
+    if (
+        image_path.name.lower() == 'images'
+        and result_path.name.lower() == 'results'
+        and image_path.parent == result_path.parent
+    ):
+        return str(image_path.parent)
+
+    temp_dir = Path(tempfile.mkdtemp(prefix='automorph_data_'))
+    atexit.register(shutil.rmtree, temp_dir, ignore_errors=True)
+
+    images_link = temp_dir / 'images'
+    results_link = temp_dir / 'Results'
+    if not images_link.exists():
+        images_link.symlink_to(image_path, target_is_directory=True)
+    if not results_link.exists():
+        results_link.symlink_to(result_path, target_is_directory=True)
+
+    resolution_link = temp_dir / 'resolution_information.csv'
+    for candidate in (
+        image_path.parent / 'resolution_information.csv',
+        result_path.parent / 'resolution_information.csv',
+    ):
+        if candidate.exists() and not resolution_link.exists():
+            resolution_link.symlink_to(candidate)
+            break
+
+    return str(temp_dir)
+
+
+AUTOMORPH_DATA = DEFAULT_AUTOMORPH_DATA
 
 def process(image_list, save_path):
     
@@ -42,6 +87,22 @@ def process(image_list, save_path):
 
 
 if __name__ == "__main__":
+    parser = ArgumentParser(description="Preprocess fundus images for AutoMorph")
+    parser.add_argument(
+        "--image_folder",
+        default=str(Path(DEFAULT_AUTOMORPH_DATA) / "images"),
+        help="Path to the folder containing source images",
+    )
+    parser.add_argument(
+        "--result_folder",
+        default=str(Path(DEFAULT_AUTOMORPH_DATA) / "Results"),
+        help="Path to the AutoMorph results folder",
+    )
+    args = parser.parse_args()
+
+    AUTOMORPH_DATA = prepare_automorph_data(args.image_folder, args.result_folder)
+    os.environ['AUTOMORPH_DATA'] = AUTOMORPH_DATA
+
     if os.path.exists(f'{AUTOMORPH_DATA}/images/.ipynb_checkpoints'):
         shutil.rmtree(f'{AUTOMORPH_DATA}/images/.ipynb_checkpoints')
     image_list = sorted(os.listdir(f'{AUTOMORPH_DATA}/images'))

--- a/M1_Retinal_Image_quality_EyePACS/merge_quality_assessment.py
+++ b/M1_Retinal_Image_quality_EyePACS/merge_quality_assessment.py
@@ -2,40 +2,103 @@ import numpy as np
 import pandas as pd
 import shutil
 import os
+from argparse import ArgumentParser
+from pathlib import Path
+import tempfile
+import atexit
 
-AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','..')
-
-result_Eyepacs = f'{AUTOMORPH_DATA}/Results/M1/results_ensemble.csv'
-
-if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M1/Good_quality/'):
-    os.makedirs(f'{AUTOMORPH_DATA}/Results/M1/Good_quality/')
-if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M1/Bad_quality/'):
-    os.makedirs(f'{AUTOMORPH_DATA}/Results/M1/Bad_quality/')
-
-result_Eyepacs_ = pd.read_csv(result_Eyepacs)
-
-Eyepacs_pre = result_Eyepacs_['Prediction']
-Eyepacs_bad_mean = result_Eyepacs_['softmax_bad']
-Eyepacs_usable_sd = result_Eyepacs_['usable_sd']
-name_list = result_Eyepacs_['Name']
-
-Eye_good = 0
-Eye_bad = 0
-
-for i in range(len(name_list)):
-    
-    if Eyepacs_pre[i]==0:
-        Eye_good+=1
-        shutil.copy(name_list[i], f'{AUTOMORPH_DATA}/Results/M1/Good_quality/')
-    elif (Eyepacs_pre[i]==1) and (Eyepacs_bad_mean[i]<0.25):
-    #elif (Eyepacs_pre[i]==1) and (Eyepacs_bad_mean[i]<0.25) and (Eyepacs_usable_sd[i]<0.1):
-        Eye_good+=1
-        shutil.copy(name_list[i], f'{AUTOMORPH_DATA}/Results/M1/Good_quality/')        
-    else:
-        Eye_bad+=1        
-        shutil.copy(name_list[i], f'{AUTOMORPH_DATA}/Results/M1/Bad_quality/')
-        #shutil.copy(name_list[i], '../Results/M1/Good_quality/')
+DEFAULT_AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA', '..')
 
 
-print('Gradable cases by EyePACS_QA is {} '.format(Eye_good))
-print('Ungradable cases by EyePACS_QA is {} '.format(Eye_bad))
+def prepare_automorph_data(image_folder, result_folder):
+
+    image_path = Path(image_folder).expanduser().resolve()
+    result_path = Path(result_folder).expanduser().resolve()
+
+    image_path.mkdir(parents=True, exist_ok=True)
+    result_path.mkdir(parents=True, exist_ok=True)
+
+    if (
+        image_path.name.lower() == 'images'
+        and result_path.name.lower() == 'results'
+        and image_path.parent == result_path.parent
+    ):
+        return str(image_path.parent)
+
+    temp_dir = Path(tempfile.mkdtemp(prefix='automorph_data_'))
+    atexit.register(shutil.rmtree, temp_dir, ignore_errors=True)
+
+    images_link = temp_dir / 'images'
+    results_link = temp_dir / 'Results'
+    if not images_link.exists():
+        images_link.symlink_to(image_path, target_is_directory=True)
+    if not results_link.exists():
+        results_link.symlink_to(result_path, target_is_directory=True)
+
+    resolution_link = temp_dir / 'resolution_information.csv'
+    for candidate in (
+        image_path.parent / 'resolution_information.csv',
+        result_path.parent / 'resolution_information.csv',
+    ):
+        if candidate.exists() and not resolution_link.exists():
+            resolution_link.symlink_to(candidate)
+            break
+
+    return str(temp_dir)
+
+
+def main():
+    parser = ArgumentParser(description='Merge AutoMorph quality assessment results')
+    parser.add_argument(
+        '--image_folder',
+        default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'images'),
+        help='Path to the folder containing input images'
+    )
+    parser.add_argument(
+        '--result_folder',
+        default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'Results'),
+        help='Path to the AutoMorph results folder'
+    )
+    args = parser.parse_args()
+
+    automorph_base = prepare_automorph_data(args.image_folder, args.result_folder)
+    os.environ['AUTOMORPH_DATA'] = automorph_base
+
+    result_Eyepacs = Path(automorph_base) / 'Results' / 'M1' / 'results_ensemble.csv'
+
+    good_quality_dir = Path(automorph_base) / 'Results' / 'M1' / 'Good_quality'
+    bad_quality_dir = Path(automorph_base) / 'Results' / 'M1' / 'Bad_quality'
+    good_quality_dir.mkdir(parents=True, exist_ok=True)
+    bad_quality_dir.mkdir(parents=True, exist_ok=True)
+
+    result_Eyepacs_ = pd.read_csv(result_Eyepacs)
+
+    Eyepacs_pre = result_Eyepacs_['Prediction']
+    Eyepacs_bad_mean = result_Eyepacs_['softmax_bad']
+    Eyepacs_usable_sd = result_Eyepacs_['usable_sd']
+    name_list = result_Eyepacs_['Name']
+
+    Eye_good = 0
+    Eye_bad = 0
+
+    for i in range(len(name_list)):
+
+        if Eyepacs_pre[i]==0:
+            Eye_good+=1
+            shutil.copy(name_list[i], good_quality_dir)
+        elif (Eyepacs_pre[i]==1) and (Eyepacs_bad_mean[i]<0.25):
+        #elif (Eyepacs_pre[i]==1) and (Eyepacs_bad_mean[i]<0.25) and (Eyepacs_usable_sd[i]<0.1):
+            Eye_good+=1
+            shutil.copy(name_list[i], good_quality_dir)
+        else:
+            Eye_bad+=1
+            shutil.copy(name_list[i], bad_quality_dir)
+            #shutil.copy(name_list[i], '../Results/M1/Good_quality/')
+
+
+    print('Gradable cases by EyePACS_QA is {} '.format(Eye_good))
+    print('Ungradable cases by EyePACS_QA is {} '.format(Eye_bad))
+
+
+if __name__ == '__main__':
+    main()

--- a/M1_Retinal_Image_quality_EyePACS/test_outside.py
+++ b/M1_Retinal_Image_quality_EyePACS/test_outside.py
@@ -12,8 +12,52 @@ from tqdm import tqdm
 from dataset import BasicDataset_OUT
 from torch.utils.data import DataLoader
 from model import Resnet101_fl, InceptionV3_fl, Densenet161_fl, Resnext101_32x8d_fl, MobilenetV2_fl, Vgg16_bn_fl, Efficientnet_fl
+from pathlib import Path
+import tempfile
+import atexit
+import shutil
 
-AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','..')
+DEFAULT_AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA', '..')
+
+
+def prepare_automorph_data(image_folder, result_folder):
+
+    image_path = Path(image_folder).expanduser().resolve()
+    result_path = Path(result_folder).expanduser().resolve()
+
+    image_path.mkdir(parents=True, exist_ok=True)
+    result_path.mkdir(parents=True, exist_ok=True)
+
+    if (
+        image_path.name.lower() == 'images'
+        and result_path.name.lower() == 'results'
+        and image_path.parent == result_path.parent
+    ):
+        return str(image_path.parent)
+
+    temp_dir = Path(tempfile.mkdtemp(prefix='automorph_data_'))
+    atexit.register(shutil.rmtree, temp_dir, ignore_errors=True)
+
+    images_link = temp_dir / 'images'
+    results_link = temp_dir / 'Results'
+    if not images_link.exists():
+        images_link.symlink_to(image_path, target_is_directory=True)
+    if not results_link.exists():
+        results_link.symlink_to(result_path, target_is_directory=True)
+
+    resolution_link = temp_dir / 'resolution_information.csv'
+    for candidate in (
+        image_path.parent / 'resolution_information.csv',
+        result_path.parent / 'resolution_information.csv',
+    ):
+        if candidate.exists() and not resolution_link.exists():
+            resolution_link.symlink_to(candidate)
+            break
+
+    return str(temp_dir)
+
+
+AUTOMORPH_DATA = DEFAULT_AUTOMORPH_DATA
 
 def test_net(model_fl_1,
             model_fl_2,
@@ -157,21 +201,38 @@ def get_args():
                         help='dataset name')
     parser.add_argument( '-t', '--task_name', dest='task', type=str,
                         help='The task name')
-    parser.add_argument( '-r', '--round', dest='round', type=int, 
-                        help='Number of round') 
-    parser.add_argument( '-m', '--model', dest='model', type=str, 
-                        help='Backbone of the model')     
+    parser.add_argument( '-r', '--round', dest='round', type=int,
+                        help='Number of round')
+    parser.add_argument( '-m', '--model', dest='model', type=str,
+                        help='Backbone of the model')
     parser.add_argument('--seed_num', type=int, default=42, help='Validation split seed', dest='seed')
-    parser.add_argument('--local_rank', default=0, type=int) 
+    parser.add_argument('--local_rank', default=0, type=int)
+    parser.add_argument(
+        '--image_folder',
+        type=str,
+        default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'images'),
+        help='Path to the folder containing input images',
+        dest='image_folder'
+    )
+    parser.add_argument(
+        '--result_folder',
+        type=str,
+        default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'Results'),
+        help='Path to the AutoMorph results folder',
+        dest='result_folder'
+    )
 
     return parser.parse_args()
 
 
 if __name__ == '__main__':
-    
+
     logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
     args = get_args()
-    
+
+    AUTOMORPH_DATA = prepare_automorph_data(args.image_folder, args.result_folder)
+    os.environ['AUTOMORPH_DATA'] = AUTOMORPH_DATA
+
 
     # Check if CUDA is available
     if torch.cuda.is_available():

--- a/M1_Retinal_Image_quality_EyePACS/test_outside.sh
+++ b/M1_Retinal_Image_quality_EyePACS/test_outside.sh
@@ -3,8 +3,19 @@ CUDA_NUMBER=0
 
 export PYTHONPATH=.:$PYTHONPATH
 
+IMAGE_FOLDER=${1:-${AUTOMORPH_IMAGE_FOLDER}}
+RESULT_FOLDER=${2:-${AUTOMORPH_RESULT_FOLDER}}
+
 if [ -z "${AUTOMORPH_DATA}" ]; then
   AUTOMORPH_DATA=".."
+fi
+
+if [ -z "${IMAGE_FOLDER}" ]; then
+  IMAGE_FOLDER="${AUTOMORPH_DATA}/images"
+fi
+
+if [ -z "${RESULT_FOLDER}" ]; then
+  RESULT_FOLDER="${AUTOMORPH_DATA}/Results"
 fi
 
 for model in 'efficientnet'
@@ -13,7 +24,8 @@ do
     do
     seed_number=$((42-2*n_round))
     CUDA_VISIBLE_DEVICES=${CUDA_NUMBER} python test_outside.py --e=1 --b=64 --task_name='Retinal_quality' --model=${model} --round=${n_round} --train_on_dataset='EyePACS_quality' \
-    --test_on_dataset='customised_data' --test_csv_dir="${AUTOMORPH_DATA}/Results/M0/images/" --n_class=3 --seed_num=${seed_number}
+    --test_on_dataset='customised_data' --test_csv_dir="${RESULT_FOLDER}/M0/images/" --n_class=3 --seed_num=${seed_number} \
+    --image_folder="${IMAGE_FOLDER}" --result_folder="${RESULT_FOLDER}"
 
     
     done

--- a/M2_Artery_vein/test_outside.sh
+++ b/M2_Artery_vein/test_outside.sh
@@ -2,16 +2,33 @@
 
 export PYTHONPATH=.:$PYTHONPATH
 
+IMAGE_FOLDER=${1:-${AUTOMORPH_IMAGE_FOLDER}}
+RESULT_FOLDER=${2:-${AUTOMORPH_RESULT_FOLDER}}
+
 seed_number=42
 dataset_name='ALL-AV'
 test_checkpoint=1401
+
+if [ -z "${AUTOMORPH_DATA}" ]; then
+  AUTOMORPH_DATA=".."
+fi
+
+if [ -z "${IMAGE_FOLDER}" ]; then
+  IMAGE_FOLDER="${AUTOMORPH_DATA}/images"
+fi
+
+if [ -z "${RESULT_FOLDER}" ]; then
+  RESULT_FOLDER="${AUTOMORPH_DATA}/Results"
+fi
 
 date
 CUDA_VISIBLE_DEVICES=0 python test_outside.py --batch-size=8 \
                                                 --dataset=${dataset_name} \
                                                 --job_name=20210724_${dataset_name}_randomseed \
                                                 --checkstart=${test_checkpoint} \
-                                                --uniform=True
+                                                --uniform=True \
+                                                --image_folder="${IMAGE_FOLDER}" \
+                                                --result_folder="${RESULT_FOLDER}"
 
 
 date

--- a/M2_Vessel_seg/test_outside.sh
+++ b/M2_Vessel_seg/test_outside.sh
@@ -1,7 +1,18 @@
 #This is sh file for SEGAN
 
+IMAGE_FOLDER=${1:-${AUTOMORPH_IMAGE_FOLDER}}
+RESULT_FOLDER=${2:-${AUTOMORPH_RESULT_FOLDER}}
+
 if [ -z "${AUTOMORPH_DATA}" ]; then
   AUTOMORPH_DATA=".."
+fi
+
+if [ -z "${IMAGE_FOLDER}" ]; then
+  IMAGE_FOLDER="${AUTOMORPH_DATA}/images"
+fi
+
+if [ -z "${RESULT_FOLDER}" ]; then
+  RESULT_FOLDER="${AUTOMORPH_DATA}/Results"
 fi
 
 # define your job name
@@ -32,7 +43,9 @@ CUDA_VISIBLE_DEVICES=${gpu_id} python test_outside_integrated.py --epochs=1 \
                                                 --train_test_mode='test' \
                                                 --pre_threshold=40.0 \
                                                 --seed_num=${seed_number} \
-                                                --out_test="${AUTOMORPH_DATA}/Results/M2/binary_vessel/"
+                                                --out_test="${RESULT_FOLDER}/M2/binary_vessel/" \
+                                                --image_folder="${IMAGE_FOLDER}" \
+                                                --result_folder="${RESULT_FOLDER}"
                                                 
                                         
 

--- a/M2_Vessel_seg/test_outside_integrated.py
+++ b/M2_Vessel_seg/test_outside_integrated.py
@@ -16,8 +16,51 @@ from skimage.morphology import skeletonize,remove_small_objects
 from skimage import io
 from FD_cal import fractal_dimension,vessel_density
 import shutil
+from pathlib import Path
+import tempfile
+import atexit
 
-AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','..')
+DEFAULT_AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA', '..')
+
+
+def prepare_automorph_data(image_folder, result_folder):
+
+    image_path = Path(image_folder).expanduser().resolve()
+    result_path = Path(result_folder).expanduser().resolve()
+
+    image_path.mkdir(parents=True, exist_ok=True)
+    result_path.mkdir(parents=True, exist_ok=True)
+
+    if (
+        image_path.name.lower() == 'images'
+        and result_path.name.lower() == 'results'
+        and image_path.parent == result_path.parent
+    ):
+        return str(image_path.parent)
+
+    temp_dir = Path(tempfile.mkdtemp(prefix='automorph_data_'))
+    atexit.register(shutil.rmtree, temp_dir, ignore_errors=True)
+
+    images_link = temp_dir / 'images'
+    results_link = temp_dir / 'Results'
+    if not images_link.exists():
+        images_link.symlink_to(image_path, target_is_directory=True)
+    if not results_link.exists():
+        results_link.symlink_to(result_path, target_is_directory=True)
+
+    resolution_link = temp_dir / 'resolution_information.csv'
+    for candidate in (
+        image_path.parent / 'resolution_information.csv',
+        result_path.parent / 'resolution_information.csv',
+    ):
+        if candidate.exists() and not resolution_link.exists():
+            resolution_link.symlink_to(candidate)
+            break
+
+    return str(temp_dir)
+
+
+AUTOMORPH_DATA = DEFAULT_AUTOMORPH_DATA
 
 def filter_frag(data_path):
     if os.path.isdir(data_path + 'resize_binary/.ipynb_checkpoints'):
@@ -267,9 +310,23 @@ def get_args():
     parser.add_argument('--validation_ratio', type=float, default=10.0, help='Percent of the data that is used as validation 0-100', dest='val')
     parser.add_argument('--uniform', type=str, default='False', help='whether to uniform the image size', dest='uniform')
     parser.add_argument('--out_test', type=str, default='False', help='whether to uniform the image size', dest='data_path')
-    
+    parser.add_argument(
+        '--image_folder',
+        type=str,
+        default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'images'),
+        help='Path to the folder containing input images',
+        dest='image_folder'
+    )
+    parser.add_argument(
+        '--result_folder',
+        type=str,
+        default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'Results'),
+        help='Path to the AutoMorph results folder',
+        dest='result_folder'
+    )
+
     ####################### Loss weights ################################
-    
+
     parser.add_argument('--alpha', type=float, default=0.08, help='Loss weight of Adversarial Loss', dest='alpha')
     parser.add_argument('--beta', type=float, default=1.1, help='Loss weight of segmentation cross entropy', dest='beta')
     parser.add_argument('--gamma', type=float, default=0.5, help='Loss weight of segmentation mean square error', dest='gamma')
@@ -278,9 +335,11 @@ def get_args():
 
 
 if __name__ == '__main__':
-    
+
     logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
     args = get_args()
+    AUTOMORPH_DATA = prepare_automorph_data(args.image_folder, args.result_folder)
+    os.environ['AUTOMORPH_DATA'] = AUTOMORPH_DATA
     # Check if CUDA is available
     if torch.cuda.is_available():
         logging.info("CUDA is available. Using CUDA...")

--- a/M2_lwnet_disc_cup/test_outside.sh
+++ b/M2_lwnet_disc_cup/test_outside.sh
@@ -1,6 +1,22 @@
 date
 
-python generate_av_results.py --config_file experiments/wnet_All_three_1024_disc_cup/30/config.cfg --im_size 512 --device cuda:0
+IMAGE_FOLDER=${1:-${AUTOMORPH_IMAGE_FOLDER}}
+RESULT_FOLDER=${2:-${AUTOMORPH_RESULT_FOLDER}}
+
+if [ -z "${AUTOMORPH_DATA}" ]; then
+  AUTOMORPH_DATA=".."
+fi
+
+if [ -z "${IMAGE_FOLDER}" ]; then
+  IMAGE_FOLDER="${AUTOMORPH_DATA}/images"
+fi
+
+if [ -z "${RESULT_FOLDER}" ]; then
+  RESULT_FOLDER="${AUTOMORPH_DATA}/Results"
+fi
+
+python generate_av_results.py --config_file experiments/wnet_All_three_1024_disc_cup/30/config.cfg --im_size 512 --device cuda:0 \
+  --image_folder="${IMAGE_FOLDER}" --result_folder="${RESULT_FOLDER}"
                            
 
 date

--- a/M3_feature_whole_pic/retipy/create_datasets_disc_centred.py
+++ b/M3_feature_whole_pic/retipy/create_datasets_disc_centred.py
@@ -30,23 +30,53 @@ import h5py
 import shutil
 import pandas as pd
 # import scipy.stats as stats
+from pathlib import Path
+import tempfile
+import atexit
 
 from retipy import configuration, retina, tortuosity_measures
 
-AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','../..')
+DEFAULT_AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','../..')
 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/artery_binary_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/artery_binary_skeleton/.ipynb_checkpoints') 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/binary_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/binary_skeleton/.ipynb_checkpoints') 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/vein_binary_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/vein_binary_skeleton/.ipynb_checkpoints')
-if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Width/'):
-    os.makedirs(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Width/')
 
-# if os.path.exists('./DDR/av_seg/raw/.ipynb_checkpoints'):
-#    shutil.rmtree('./DDR/av_seg/raw/.ipynb_checkpoints') 
+def prepare_automorph_data(image_folder, result_folder):
 
+    image_path = Path(image_folder).expanduser().resolve()
+    result_path = Path(result_folder).expanduser().resolve()
+
+    image_path.mkdir(parents=True, exist_ok=True)
+    result_path.mkdir(parents=True, exist_ok=True)
+
+    if (
+        image_path.name.lower() == 'images'
+        and result_path.name.lower() == 'results'
+        and image_path.parent == result_path.parent
+    ):
+        return str(image_path.parent)
+
+    temp_dir = Path(tempfile.mkdtemp(prefix='automorph_data_'))
+    atexit.register(shutil.rmtree, temp_dir, ignore_errors=True)
+
+    images_link = temp_dir / 'images'
+    results_link = temp_dir / 'Results'
+    if not images_link.exists():
+        images_link.symlink_to(image_path, target_is_directory=True)
+    if not results_link.exists():
+        results_link.symlink_to(result_path, target_is_directory=True)
+
+    resolution_link = temp_dir / 'resolution_information.csv'
+    for candidate in (
+        image_path.parent / 'resolution_information.csv',
+        result_path.parent / 'resolution_information.csv',
+    ):
+        if candidate.exists() and not resolution_link.exists():
+            resolution_link.symlink_to(candidate)
+            break
+
+    return str(temp_dir)
+
+
+AUTOMORPH_DATA = DEFAULT_AUTOMORPH_DATA
 
 parser = argparse.ArgumentParser()
 
@@ -55,7 +85,33 @@ parser.add_argument(
     "--configuration",
     help="the configuration file location",
     default="resources/retipy.config")
+parser.add_argument(
+    "--image_folder",
+    default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'images'),
+    help="Path to the folder containing input images"
+)
+parser.add_argument(
+    "--result_folder",
+    default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'Results'),
+    help="Path to the AutoMorph results folder"
+)
 args = parser.parse_args()
+
+AUTOMORPH_DATA = prepare_automorph_data(args.image_folder, args.result_folder)
+os.environ['AUTOMORPH_DATA'] = AUTOMORPH_DATA
+
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/artery_binary_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/artery_binary_skeleton/.ipynb_checkpoints')
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/binary_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/binary_skeleton/.ipynb_checkpoints')
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/vein_binary_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/vein_binary_skeleton/.ipynb_checkpoints')
+if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Width/'):
+    os.makedirs(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Width/')
+
+# if os.path.exists('./DDR/av_seg/raw/.ipynb_checkpoints'):
+#    shutil.rmtree('./DDR/av_seg/raw/.ipynb_checkpoints')
+
 
 CONFIG = configuration.Configuration(args.configuration)
 binary_FD_binary,binary_VD_binary,binary_Average_width,binary_t2_list,binary_t4_list,binary_t5_list = [],[],[],[],[],[]

--- a/M3_feature_whole_pic/retipy/create_datasets_macular_centred.py
+++ b/M3_feature_whole_pic/retipy/create_datasets_macular_centred.py
@@ -30,23 +30,53 @@ import h5py
 import shutil
 import pandas as pd
 # import scipy.stats as stats
+from pathlib import Path
+import tempfile
+import atexit
 
 from retipy import configuration, retina, tortuosity_measures
 
-AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','../..')
+DEFAULT_AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','../..')
 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/artery_binary_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/artery_binary_skeleton/.ipynb_checkpoints') 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/binary_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/binary_skeleton/.ipynb_checkpoints') 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/vein_binary_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/vein_binary_skeleton/.ipynb_checkpoints')
-if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Width/'):
-    os.makedirs(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Width/')
 
-#if os.path.exists('./DDR/av_seg/raw/.ipynb_checkpoints'):
-#    shutil.rmtree('./DDR/av_seg/raw/.ipynb_checkpoints') 
+def prepare_automorph_data(image_folder, result_folder):
 
+    image_path = Path(image_folder).expanduser().resolve()
+    result_path = Path(result_folder).expanduser().resolve()
+
+    image_path.mkdir(parents=True, exist_ok=True)
+    result_path.mkdir(parents=True, exist_ok=True)
+
+    if (
+        image_path.name.lower() == 'images'
+        and result_path.name.lower() == 'results'
+        and image_path.parent == result_path.parent
+    ):
+        return str(image_path.parent)
+
+    temp_dir = Path(tempfile.mkdtemp(prefix='automorph_data_'))
+    atexit.register(shutil.rmtree, temp_dir, ignore_errors=True)
+
+    images_link = temp_dir / 'images'
+    results_link = temp_dir / 'Results'
+    if not images_link.exists():
+        images_link.symlink_to(image_path, target_is_directory=True)
+    if not results_link.exists():
+        results_link.symlink_to(result_path, target_is_directory=True)
+
+    resolution_link = temp_dir / 'resolution_information.csv'
+    for candidate in (
+        image_path.parent / 'resolution_information.csv',
+        result_path.parent / 'resolution_information.csv',
+    ):
+        if candidate.exists() and not resolution_link.exists():
+            resolution_link.symlink_to(candidate)
+            break
+
+    return str(temp_dir)
+
+
+AUTOMORPH_DATA = DEFAULT_AUTOMORPH_DATA
 
 parser = argparse.ArgumentParser()
 
@@ -55,7 +85,33 @@ parser.add_argument(
     "--configuration",
     help="the configuration file location",
     default="resources/retipy.config")
+parser.add_argument(
+    "--image_folder",
+    default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'images'),
+    help="Path to the folder containing input images"
+)
+parser.add_argument(
+    "--result_folder",
+    default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'Results'),
+    help="Path to the AutoMorph results folder"
+)
 args = parser.parse_args()
+
+AUTOMORPH_DATA = prepare_automorph_data(args.image_folder, args.result_folder)
+os.environ['AUTOMORPH_DATA'] = AUTOMORPH_DATA
+
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/artery_binary_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/artery_binary_skeleton/.ipynb_checkpoints')
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/binary_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/binary_skeleton/.ipynb_checkpoints')
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/vein_binary_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/vein_binary_skeleton/.ipynb_checkpoints')
+if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Width/'):
+    os.makedirs(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Width/')
+
+#if os.path.exists('./DDR/av_seg/raw/.ipynb_checkpoints'):
+#    shutil.rmtree('./DDR/av_seg/raw/.ipynb_checkpoints')
+
 
 CONFIG = configuration.Configuration(args.configuration)
 binary_FD_binary,binary_VD_binary,binary_Average_width,binary_t2_list,binary_t4_list,binary_t5_list = [],[],[],[],[],[]

--- a/M3_feature_zone/retipy/create_datasets_disc_centred_B.py
+++ b/M3_feature_zone/retipy/create_datasets_disc_centred_B.py
@@ -30,23 +30,53 @@ import h5py
 import shutil
 import pandas as pd
 # import scipy.stats as stats
+from pathlib import Path
+import tempfile
+import atexit
 
 from retipy import configuration, retina, tortuosity_measures
 
-AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','../..')
+DEFAULT_AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','../..')
 
 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_B_disc_centred_artery_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_B_disc_centred_artery_skeleton/.ipynb_checkpoints') 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/Zone_B_disc_centred_binary_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/Zone_B_disc_centred_binary_skeleton/.ipynb_checkpoints') 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_B_disc_centred_vein_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_B_disc_centred_vein_skeleton/.ipynb_checkpoints')
-if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Width/'):
-    os.makedirs(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Width/')
+def prepare_automorph_data(image_folder, result_folder):
 
-#if os.path.exists('./DDR/av_seg/raw/.ipynb_checkpoints'):
-#    shutil.rmtree('./DDR/av_seg/raw/.ipynb_checkpoints') 
+    image_path = Path(image_folder).expanduser().resolve()
+    result_path = Path(result_folder).expanduser().resolve()
+
+    image_path.mkdir(parents=True, exist_ok=True)
+    result_path.mkdir(parents=True, exist_ok=True)
+
+    if (
+        image_path.name.lower() == 'images'
+        and result_path.name.lower() == 'results'
+        and image_path.parent == result_path.parent
+    ):
+        return str(image_path.parent)
+
+    temp_dir = Path(tempfile.mkdtemp(prefix='automorph_data_'))
+    atexit.register(shutil.rmtree, temp_dir, ignore_errors=True)
+
+    images_link = temp_dir / 'images'
+    results_link = temp_dir / 'Results'
+    if not images_link.exists():
+        images_link.symlink_to(image_path, target_is_directory=True)
+    if not results_link.exists():
+        results_link.symlink_to(result_path, target_is_directory=True)
+
+    resolution_link = temp_dir / 'resolution_information.csv'
+    for candidate in (
+        image_path.parent / 'resolution_information.csv',
+        result_path.parent / 'resolution_information.csv',
+    ):
+        if candidate.exists() and not resolution_link.exists():
+            resolution_link.symlink_to(candidate)
+            break
+
+    return str(temp_dir)
+
+
+AUTOMORPH_DATA = DEFAULT_AUTOMORPH_DATA
 
 
 parser = argparse.ArgumentParser()
@@ -56,7 +86,33 @@ parser.add_argument(
     "--configuration",
     help="the configuration file location",
     default="resources/retipy.config")
+parser.add_argument(
+    "--image_folder",
+    default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'images'),
+    help="Path to the folder containing input images"
+)
+parser.add_argument(
+    "--result_folder",
+    default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'Results'),
+    help="Path to the AutoMorph results folder"
+)
 args = parser.parse_args()
+
+
+AUTOMORPH_DATA = prepare_automorph_data(args.image_folder, args.result_folder)
+os.environ['AUTOMORPH_DATA'] = AUTOMORPH_DATA
+
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_B_disc_centred_artery_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_B_disc_centred_artery_skeleton/.ipynb_checkpoints')
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/Zone_B_disc_centred_binary_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/Zone_B_disc_centred_binary_skeleton/.ipynb_checkpoints')
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_B_disc_centred_vein_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_B_disc_centred_vein_skeleton/.ipynb_checkpoints')
+if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Width/'):
+    os.makedirs(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Width/')
+
+#if os.path.exists('./DDR/av_seg/raw/.ipynb_checkpoints'):
+#    shutil.rmtree('./DDR/av_seg/raw/.ipynb_checkpoints')
 
 
 CONFIG = configuration.Configuration(args.configuration)

--- a/M3_feature_zone/retipy/create_datasets_disc_centred_C.py
+++ b/M3_feature_zone/retipy/create_datasets_disc_centred_C.py
@@ -30,22 +30,53 @@ import h5py
 import shutil
 import pandas as pd
 # import scipy.stats as stats
+from pathlib import Path
+import tempfile
+import atexit
 
 from retipy import configuration, retina, tortuosity_measures
 
-AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','../..')
+DEFAULT_AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','../..')
 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_C_disc_centred_artery_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_C_disc_centred_artery_skeleton/.ipynb_checkpoints') 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/Zone_C_disc_centred_binary_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/Zone_C_disc_centred_binary_skeleton/.ipynb_checkpoints') 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_C_disc_centred_vein_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_C_disc_centred_vein_skeleton/.ipynb_checkpoints')
-if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Width/'):
-    os.makedirs(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Width/')
 
-#if os.path.exists('./DDR/av_seg/raw/.ipynb_checkpoints'):
-#    shutil.rmtree('./DDR/av_seg/raw/.ipynb_checkpoints') 
+def prepare_automorph_data(image_folder, result_folder):
+
+    image_path = Path(image_folder).expanduser().resolve()
+    result_path = Path(result_folder).expanduser().resolve()
+
+    image_path.mkdir(parents=True, exist_ok=True)
+    result_path.mkdir(parents=True, exist_ok=True)
+
+    if (
+        image_path.name.lower() == 'images'
+        and result_path.name.lower() == 'results'
+        and image_path.parent == result_path.parent
+    ):
+        return str(image_path.parent)
+
+    temp_dir = Path(tempfile.mkdtemp(prefix='automorph_data_'))
+    atexit.register(shutil.rmtree, temp_dir, ignore_errors=True)
+
+    images_link = temp_dir / 'images'
+    results_link = temp_dir / 'Results'
+    if not images_link.exists():
+        images_link.symlink_to(image_path, target_is_directory=True)
+    if not results_link.exists():
+        results_link.symlink_to(result_path, target_is_directory=True)
+
+    resolution_link = temp_dir / 'resolution_information.csv'
+    for candidate in (
+        image_path.parent / 'resolution_information.csv',
+        result_path.parent / 'resolution_information.csv',
+    ):
+        if candidate.exists() and not resolution_link.exists():
+            resolution_link.symlink_to(candidate)
+            break
+
+    return str(temp_dir)
+
+
+AUTOMORPH_DATA = DEFAULT_AUTOMORPH_DATA
 
 
 parser = argparse.ArgumentParser()
@@ -55,7 +86,33 @@ parser.add_argument(
     "--configuration",
     help="the configuration file location",
     default="resources/retipy.config")
+parser.add_argument(
+    "--image_folder",
+    default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'images'),
+    help="Path to the folder containing input images"
+)
+parser.add_argument(
+    "--result_folder",
+    default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'Results'),
+    help="Path to the AutoMorph results folder"
+)
 args = parser.parse_args()
+
+
+AUTOMORPH_DATA = prepare_automorph_data(args.image_folder, args.result_folder)
+os.environ['AUTOMORPH_DATA'] = AUTOMORPH_DATA
+
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_C_disc_centred_artery_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_C_disc_centred_artery_skeleton/.ipynb_checkpoints')
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/Zone_C_disc_centred_binary_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/Zone_C_disc_centred_binary_skeleton/.ipynb_checkpoints')
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_C_disc_centred_vein_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_C_disc_centred_vein_skeleton/.ipynb_checkpoints')
+if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Width/'):
+    os.makedirs(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Width/')
+
+#if os.path.exists('./DDR/av_seg/raw/.ipynb_checkpoints'):
+#    shutil.rmtree('./DDR/av_seg/raw/.ipynb_checkpoints')
 
 
 CONFIG = configuration.Configuration(args.configuration)

--- a/M3_feature_zone/retipy/create_datasets_macular_centred_B.py
+++ b/M3_feature_zone/retipy/create_datasets_macular_centred_B.py
@@ -30,22 +30,53 @@ import h5py
 import shutil
 import pandas as pd
 # import scipy.stats as stats
+from pathlib import Path
+import tempfile
+import atexit
 
 from retipy import configuration, retina, tortuosity_measures
 
-AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','../..')
+DEFAULT_AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','../..')
 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/macular_Zone_B_centred_artery_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/macular_Zone_B_centred_artery_skeleton/.ipynb_checkpoints') 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/macular_Zone_B_centred_vein_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/macular_Zone_B_centred_vein_skeleton/.ipynb_checkpoints') 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/macular_Zone_B_centred_binary_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/macular_Zone_B_centred_binary_skeleton/.ipynb_checkpoints')
-if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Width/'):
-    os.makedirs(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Width/')
 
-#if os.path.exists('./DDR/av_seg/raw/.ipynb_checkpoints'):
-#    shutil.rmtree('./DDR/av_seg/raw/.ipynb_checkpoints') 
+def prepare_automorph_data(image_folder, result_folder):
+
+    image_path = Path(image_folder).expanduser().resolve()
+    result_path = Path(result_folder).expanduser().resolve()
+
+    image_path.mkdir(parents=True, exist_ok=True)
+    result_path.mkdir(parents=True, exist_ok=True)
+
+    if (
+        image_path.name.lower() == 'images'
+        and result_path.name.lower() == 'results'
+        and image_path.parent == result_path.parent
+    ):
+        return str(image_path.parent)
+
+    temp_dir = Path(tempfile.mkdtemp(prefix='automorph_data_'))
+    atexit.register(shutil.rmtree, temp_dir, ignore_errors=True)
+
+    images_link = temp_dir / 'images'
+    results_link = temp_dir / 'Results'
+    if not images_link.exists():
+        images_link.symlink_to(image_path, target_is_directory=True)
+    if not results_link.exists():
+        results_link.symlink_to(result_path, target_is_directory=True)
+
+    resolution_link = temp_dir / 'resolution_information.csv'
+    for candidate in (
+        image_path.parent / 'resolution_information.csv',
+        result_path.parent / 'resolution_information.csv',
+    ):
+        if candidate.exists() and not resolution_link.exists():
+            resolution_link.symlink_to(candidate)
+            break
+
+    return str(temp_dir)
+
+
+AUTOMORPH_DATA = DEFAULT_AUTOMORPH_DATA
 
 
 parser = argparse.ArgumentParser()
@@ -55,7 +86,33 @@ parser.add_argument(
     "--configuration",
     help="the configuration file location",
     default="resources/retipy.config")
+parser.add_argument(
+    "--image_folder",
+    default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'images'),
+    help="Path to the folder containing input images"
+)
+parser.add_argument(
+    "--result_folder",
+    default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'Results'),
+    help="Path to the AutoMorph results folder"
+)
 args = parser.parse_args()
+
+AUTOMORPH_DATA = prepare_automorph_data(args.image_folder, args.result_folder)
+os.environ['AUTOMORPH_DATA'] = AUTOMORPH_DATA
+
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/macular_Zone_B_centred_artery_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/macular_Zone_B_centred_artery_skeleton/.ipynb_checkpoints')
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/macular_Zone_B_centred_vein_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/macular_Zone_B_centred_vein_skeleton/.ipynb_checkpoints')
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/macular_Zone_B_centred_binary_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/macular_Zone_B_centred_binary_skeleton/.ipynb_checkpoints')
+if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Width/'):
+    os.makedirs(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Width/')
+
+#if os.path.exists('./DDR/av_seg/raw/.ipynb_checkpoints'):
+#    shutil.rmtree('./DDR/av_seg/raw/.ipynb_checkpoints')
+
 
 CONFIG = configuration.Configuration(args.configuration)
 binary_FD_binary,binary_VD_binary,binary_Average_width,binary_t2_list,binary_t4_list,binary_t5_list = [],[],[],[],[],[]

--- a/csv_merge.py
+++ b/csv_merge.py
@@ -1,40 +1,103 @@
 import shutil
 import os
 import pandas as pd
+from argparse import ArgumentParser
+from pathlib import Path
+import tempfile
+import atexit
 
-AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','.')
+DEFAULT_AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','.')
 
-# merge all csvs
-Disc_whole_image = pd.read_csv(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Disc_Measurement.csv')
-Disc_zone_b = pd.read_csv(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Disc_Zone_B_Measurement.csv')
-Disc_zone_c = pd.read_csv(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Disc_Zone_C_Measurement.csv')
 
-Macular_whole_image = pd.read_csv(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Macular_Measurement.csv')
-Macular_zone_b = pd.read_csv(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Macular_Zone_B_Measurement.csv')
-Macular_zone_c = pd.read_csv(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Macular_Zone_C_Measurement.csv')
+def prepare_automorph_data(image_folder, result_folder):
 
-Disc_zone = Disc_zone_b.merge(Disc_zone_c, how = 'outer', on = ['Name', 'Disc_height', 'Disc_width', 'Cup_height', 'Cup_width', \
+    image_path = Path(image_folder).expanduser().resolve()
+    result_path = Path(result_folder).expanduser().resolve()
+
+    image_path.mkdir(parents=True, exist_ok=True)
+    result_path.mkdir(parents=True, exist_ok=True)
+
+    if (
+        image_path.name.lower() == 'images'
+        and result_path.name.lower() == 'results'
+        and image_path.parent == result_path.parent
+    ):
+        return str(image_path.parent)
+
+    temp_dir = Path(tempfile.mkdtemp(prefix='automorph_data_'))
+    atexit.register(shutil.rmtree, temp_dir, ignore_errors=True)
+
+    images_link = temp_dir / 'images'
+    results_link = temp_dir / 'Results'
+    if not images_link.exists():
+        images_link.symlink_to(image_path, target_is_directory=True)
+    if not results_link.exists():
+        results_link.symlink_to(result_path, target_is_directory=True)
+
+    resolution_link = temp_dir / 'resolution_information.csv'
+    for candidate in (
+        image_path.parent / 'resolution_information.csv',
+        result_path.parent / 'resolution_information.csv',
+    ):
+        if candidate.exists() and not resolution_link.exists():
+            resolution_link.symlink_to(candidate)
+            break
+
+    return str(temp_dir)
+
+
+def main():
+    parser = ArgumentParser(description='Merge AutoMorph CSV outputs')
+    parser.add_argument(
+        '--image_folder',
+        default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'images'),
+        help='Path to the folder containing input images'
+    )
+    parser.add_argument(
+        '--result_folder',
+        default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'Results'),
+        help='Path to the AutoMorph results folder'
+    )
+    args = parser.parse_args()
+
+    automorph_base = prepare_automorph_data(args.image_folder, args.result_folder)
+    os.environ['AUTOMORPH_DATA'] = automorph_base
+
+    # merge all csvs
+    Disc_whole_image = pd.read_csv(f'{automorph_base}/Results/M3/Disc_centred/Disc_Measurement.csv')
+    Disc_zone_b = pd.read_csv(f'{automorph_base}/Results/M3/Disc_centred/Disc_Zone_B_Measurement.csv')
+    Disc_zone_c = pd.read_csv(f'{automorph_base}/Results/M3/Disc_centred/Disc_Zone_C_Measurement.csv')
+
+    Macular_whole_image = pd.read_csv(f'{automorph_base}/Results/M3/Macular_centred/Macular_Measurement.csv')
+    Macular_zone_b = pd.read_csv(f'{automorph_base}/Results/M3/Macular_centred/Macular_Zone_B_Measurement.csv')
+    Macular_zone_c = pd.read_csv(f'{automorph_base}/Results/M3/Macular_centred/Macular_Zone_C_Measurement.csv')
+
+    Disc_zone = Disc_zone_b.merge(Disc_zone_c, how='outer', on=['Name', 'Disc_height', 'Disc_width', 'Cup_height', 'Cup_width',
                                                                 'CDR_vertical', 'CDR_horizontal'], suffixes=('_zone_b', '_zone_c'))
 
-Disc_all = Disc_whole_image.merge(Disc_zone, how = 'outer', on = ['Name', 'Disc_height', 'Disc_width', 'Cup_height', 'Cup_width', \
-                                                                'CDR_vertical', 'CDR_horizontal'])
+    Disc_all = Disc_whole_image.merge(Disc_zone, how='outer', on=['Name', 'Disc_height', 'Disc_width', 'Cup_height', 'Cup_width',
+                                                                  'CDR_vertical', 'CDR_horizontal'])
 
 
-Macular_zone = Macular_zone_b.merge(Macular_zone_c, how = 'outer', on = ['Name', 'Disc_height', 'Disc_width', 'Cup_height', 'Cup_width', \
+    Macular_zone = Macular_zone_b.merge(Macular_zone_c, how='outer', on=['Name', 'Disc_height', 'Disc_width', 'Cup_height', 'Cup_width',
                                                                          'CDR_vertical', 'CDR_horizontal'], suffixes=('_zone_b', '_zone_c'))
 
-Macular_all = Macular_whole_image.merge(Macular_zone, how = 'outer', on = ['Name', 'Disc_height', 'Disc_width', 'Cup_height', 'Cup_width', \
-                                                                         'CDR_vertical', 'CDR_horizontal'])
+    Macular_all = Macular_whole_image.merge(Macular_zone, how='outer', on=['Name', 'Disc_height', 'Disc_width', 'Cup_height', 'Cup_width',
+                                                                           'CDR_vertical', 'CDR_horizontal'])
 
 
-# replace all -1 with empty string
-Disc_all.replace(-1, "", inplace=True)
-Macular_all.replace(-1, "", inplace=True)
+    # replace all -1 with empty string
+    Disc_all.replace(-1, "", inplace=True)
+    Macular_all.replace(-1, "", inplace=True)
 
-Disc_all.to_csv(f'{AUTOMORPH_DATA}/Results/M3/Disc_Features.csv', index=False)
-Macular_all.to_csv(f'{AUTOMORPH_DATA}/Results/M3/Macular_Features.csv', index=False)
+    Disc_all.to_csv(f'{automorph_base}/Results/M3/Disc_Features.csv', index=False)
+    Macular_all.to_csv(f'{automorph_base}/Results/M3/Macular_Features.csv', index=False)
 
-# remove the sub csvs
-shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/')
-shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/')
+    # remove the sub csvs
+    shutil.rmtree(f'{automorph_base}/Results/M3/Disc_centred/')
+    shutil.rmtree(f'{automorph_base}/Results/M3/Macular_centred/')
+
+
+if __name__ == '__main__':
+    main()
 


### PR DESCRIPTION
## Summary
- add image/result folder arguments to all AutoMorph pipeline stages and propagate them through helper shell scripts
- introduce reusable path preparation logic that links arbitrary directories into the expected AutoMorph layout before execution
- update run.sh to accept absolute paths and forward them to every Python component, including CSV merging

## Testing
- python -m compileall M0_Preprocess/EyeQ_process_main.py M1_Retinal_Image_quality_EyePACS/test_outside.py M1_Retinal_Image_quality_EyePACS/merge_quality_assessment.py M2_Vessel_seg/test_outside_integrated.py M2_Artery_vein/test_outside.py M2_lwnet_disc_cup/generate_av_results.py M3_feature_zone/retipy/create_datasets_disc_centred_B.py M3_feature_zone/retipy/create_datasets_disc_centred_C.py M3_feature_zone/retipy/create_datasets_macular_centred_B.py M3_feature_zone/retipy/create_datasets_macular_centred_C.py M3_feature_whole_pic/retipy/create_datasets_disc_centred.py M3_feature_whole_pic/retipy/create_datasets_macular_centred.py csv_merge.py

------
https://chatgpt.com/codex/tasks/task_e_68e63a2e4e248330b0432a8fe40cba0d