### PR TITLE
Ensure resolution CSV follows provided paths

### DIFF
--- a/LOCAL.md
+++ b/LOCAL.md
@@ -44,6 +44,15 @@ Put the images in folder 'images' and
 sh run.sh
 ```
 
+To run the pipeline with explicit folders, provide absolute or relative paths
+via the new command-line options, for example:
+
+```bash
+sh run.sh --image_folder=/data/fundus/images --result_folder=/data/fundus/results
+```
+
+The script will create the results directory if it does not exist.
+
 Please note that resolution_information.csv includes the resolution for image, i.e., size for each pixel. Please prepare it for the customised data in the same format.
 
 

--- a/M0_Preprocess/EyeQ_process_main.py
+++ b/M0_Preprocess/EyeQ_process_main.py
@@ -1,11 +1,21 @@
 import fundus_prep as prep
 import os
+import sys
 import pandas as pd
 from PIL import ImageFile
 import shutil
+from argparse import ArgumentParser
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from automorph_paths import prepare_automorph_data
+
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 
-AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','..')
+DEFAULT_AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA', '..')
+
+
+AUTOMORPH_DATA = DEFAULT_AUTOMORPH_DATA
 
 def process(image_list, save_path):
     
@@ -42,6 +52,21 @@ def process(image_list, save_path):
 
 
 if __name__ == "__main__":
+    parser = ArgumentParser(description="Preprocess fundus images for AutoMorph")
+    parser.add_argument(
+        "--image_folder",
+        default=str(Path(DEFAULT_AUTOMORPH_DATA) / "images"),
+        help="Path to the folder containing source images",
+    )
+    parser.add_argument(
+        "--result_folder",
+        default=str(Path(DEFAULT_AUTOMORPH_DATA) / "Results"),
+        help="Path to the AutoMorph results folder",
+    )
+    args = parser.parse_args()
+
+    AUTOMORPH_DATA, _ = prepare_automorph_data(args.image_folder, args.result_folder)
+
     if os.path.exists(f'{AUTOMORPH_DATA}/images/.ipynb_checkpoints'):
         shutil.rmtree(f'{AUTOMORPH_DATA}/images/.ipynb_checkpoints')
     image_list = sorted(os.listdir(f'{AUTOMORPH_DATA}/images'))

--- a/M1_Retinal_Image_quality_EyePACS/merge_quality_assessment.py
+++ b/M1_Retinal_Image_quality_EyePACS/merge_quality_assessment.py
@@ -2,40 +2,67 @@ import numpy as np
 import pandas as pd
 import shutil
 import os
+import sys
+from argparse import ArgumentParser
+from pathlib import Path
 
-AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','..')
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from automorph_paths import prepare_automorph_data
 
-result_Eyepacs = f'{AUTOMORPH_DATA}/Results/M1/results_ensemble.csv'
-
-if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M1/Good_quality/'):
-    os.makedirs(f'{AUTOMORPH_DATA}/Results/M1/Good_quality/')
-if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M1/Bad_quality/'):
-    os.makedirs(f'{AUTOMORPH_DATA}/Results/M1/Bad_quality/')
-
-result_Eyepacs_ = pd.read_csv(result_Eyepacs)
-
-Eyepacs_pre = result_Eyepacs_['Prediction']
-Eyepacs_bad_mean = result_Eyepacs_['softmax_bad']
-Eyepacs_usable_sd = result_Eyepacs_['usable_sd']
-name_list = result_Eyepacs_['Name']
-
-Eye_good = 0
-Eye_bad = 0
-
-for i in range(len(name_list)):
-    
-    if Eyepacs_pre[i]==0:
-        Eye_good+=1
-        shutil.copy(name_list[i], f'{AUTOMORPH_DATA}/Results/M1/Good_quality/')
-    elif (Eyepacs_pre[i]==1) and (Eyepacs_bad_mean[i]<0.25):
-    #elif (Eyepacs_pre[i]==1) and (Eyepacs_bad_mean[i]<0.25) and (Eyepacs_usable_sd[i]<0.1):
-        Eye_good+=1
-        shutil.copy(name_list[i], f'{AUTOMORPH_DATA}/Results/M1/Good_quality/')        
-    else:
-        Eye_bad+=1        
-        shutil.copy(name_list[i], f'{AUTOMORPH_DATA}/Results/M1/Bad_quality/')
-        #shutil.copy(name_list[i], '../Results/M1/Good_quality/')
+DEFAULT_AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA', '..')
 
 
-print('Gradable cases by EyePACS_QA is {} '.format(Eye_good))
-print('Ungradable cases by EyePACS_QA is {} '.format(Eye_bad))
+def main():
+    parser = ArgumentParser(description='Merge AutoMorph quality assessment results')
+    parser.add_argument(
+        '--image_folder',
+        default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'images'),
+        help='Path to the folder containing input images'
+    )
+    parser.add_argument(
+        '--result_folder',
+        default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'Results'),
+        help='Path to the AutoMorph results folder'
+    )
+    args = parser.parse_args()
+
+    automorph_base, _ = prepare_automorph_data(args.image_folder, args.result_folder)
+
+    result_Eyepacs = Path(automorph_base) / 'Results' / 'M1' / 'results_ensemble.csv'
+
+    good_quality_dir = Path(automorph_base) / 'Results' / 'M1' / 'Good_quality'
+    bad_quality_dir = Path(automorph_base) / 'Results' / 'M1' / 'Bad_quality'
+    good_quality_dir.mkdir(parents=True, exist_ok=True)
+    bad_quality_dir.mkdir(parents=True, exist_ok=True)
+
+    result_Eyepacs_ = pd.read_csv(result_Eyepacs)
+
+    Eyepacs_pre = result_Eyepacs_['Prediction']
+    Eyepacs_bad_mean = result_Eyepacs_['softmax_bad']
+    Eyepacs_usable_sd = result_Eyepacs_['usable_sd']
+    name_list = result_Eyepacs_['Name']
+
+    Eye_good = 0
+    Eye_bad = 0
+
+    for i in range(len(name_list)):
+
+        if Eyepacs_pre[i]==0:
+            Eye_good+=1
+            shutil.copy(name_list[i], good_quality_dir)
+        elif (Eyepacs_pre[i]==1) and (Eyepacs_bad_mean[i]<0.25):
+        #elif (Eyepacs_pre[i]==1) and (Eyepacs_bad_mean[i]<0.25) and (Eyepacs_usable_sd[i]<0.1):
+            Eye_good+=1
+            shutil.copy(name_list[i], good_quality_dir)
+        else:
+            Eye_bad+=1
+            shutil.copy(name_list[i], bad_quality_dir)
+            #shutil.copy(name_list[i], '../Results/M1/Good_quality/')
+
+
+    print('Gradable cases by EyePACS_QA is {} '.format(Eye_good))
+    print('Ungradable cases by EyePACS_QA is {} '.format(Eye_bad))
+
+
+if __name__ == '__main__':
+    main()

--- a/M1_Retinal_Image_quality_EyePACS/test_outside.py
+++ b/M1_Retinal_Image_quality_EyePACS/test_outside.py
@@ -12,8 +12,15 @@ from tqdm import tqdm
 from dataset import BasicDataset_OUT
 from torch.utils.data import DataLoader
 from model import Resnet101_fl, InceptionV3_fl, Densenet161_fl, Resnext101_32x8d_fl, MobilenetV2_fl, Vgg16_bn_fl, Efficientnet_fl
+from pathlib import Path
 
-AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','..')
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from automorph_paths import prepare_automorph_data
+
+DEFAULT_AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA', '..')
+
+
+AUTOMORPH_DATA = DEFAULT_AUTOMORPH_DATA
 
 def test_net(model_fl_1,
             model_fl_2,
@@ -157,21 +164,38 @@ def get_args():
                         help='dataset name')
     parser.add_argument( '-t', '--task_name', dest='task', type=str,
                         help='The task name')
-    parser.add_argument( '-r', '--round', dest='round', type=int, 
-                        help='Number of round') 
-    parser.add_argument( '-m', '--model', dest='model', type=str, 
-                        help='Backbone of the model')     
+    parser.add_argument( '-r', '--round', dest='round', type=int,
+                        help='Number of round')
+    parser.add_argument( '-m', '--model', dest='model', type=str,
+                        help='Backbone of the model')
     parser.add_argument('--seed_num', type=int, default=42, help='Validation split seed', dest='seed')
-    parser.add_argument('--local_rank', default=0, type=int) 
+    parser.add_argument('--local_rank', default=0, type=int)
+    parser.add_argument(
+        '--image_folder',
+        type=str,
+        default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'images'),
+        help='Path to the folder containing input images',
+        dest='image_folder'
+    )
+    parser.add_argument(
+        '--result_folder',
+        type=str,
+        default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'Results'),
+        help='Path to the AutoMorph results folder',
+        dest='result_folder'
+    )
 
     return parser.parse_args()
 
 
 if __name__ == '__main__':
-    
+
     logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
     args = get_args()
-    
+
+    AUTOMORPH_DATA, _ = prepare_automorph_data(args.image_folder, args.result_folder)
+    os.environ['AUTOMORPH_DATA'] = AUTOMORPH_DATA
+
 
     # Check if CUDA is available
     if torch.cuda.is_available():

--- a/M1_Retinal_Image_quality_EyePACS/test_outside.sh
+++ b/M1_Retinal_Image_quality_EyePACS/test_outside.sh
@@ -3,8 +3,19 @@ CUDA_NUMBER=0
 
 export PYTHONPATH=.:$PYTHONPATH
 
+IMAGE_FOLDER=${1:-${AUTOMORPH_IMAGE_FOLDER}}
+RESULT_FOLDER=${2:-${AUTOMORPH_RESULT_FOLDER}}
+
 if [ -z "${AUTOMORPH_DATA}" ]; then
   AUTOMORPH_DATA=".."
+fi
+
+if [ -z "${IMAGE_FOLDER}" ]; then
+  IMAGE_FOLDER="${AUTOMORPH_DATA}/images"
+fi
+
+if [ -z "${RESULT_FOLDER}" ]; then
+  RESULT_FOLDER="${AUTOMORPH_DATA}/Results"
 fi
 
 for model in 'efficientnet'
@@ -13,7 +24,8 @@ do
     do
     seed_number=$((42-2*n_round))
     CUDA_VISIBLE_DEVICES=${CUDA_NUMBER} python test_outside.py --e=1 --b=64 --task_name='Retinal_quality' --model=${model} --round=${n_round} --train_on_dataset='EyePACS_quality' \
-    --test_on_dataset='customised_data' --test_csv_dir="${AUTOMORPH_DATA}/Results/M0/images/" --n_class=3 --seed_num=${seed_number}
+    --test_on_dataset='customised_data' --test_csv_dir="${RESULT_FOLDER}/M0/images/" --n_class=3 --seed_num=${seed_number} \
+    --image_folder="${IMAGE_FOLDER}" --result_folder="${RESULT_FOLDER}"
 
     
     done

--- a/M2_Artery_vein/test_outside.py
+++ b/M2_Artery_vein/test_outside.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 import shutil
 import os
+import sys
 import cv2
 import torchvision
 import torch
@@ -19,8 +20,15 @@ from skimage import io
 from scripts.utils import Define_image_size
 from FD_cal import fractal_dimension,vessel_density
 from skimage.morphology import skeletonize,remove_small_objects
+from pathlib import Path
 
-AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','..')
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from automorph_paths import prepare_automorph_data
+
+DEFAULT_AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA', '..')
+
+
+AUTOMORPH_DATA = DEFAULT_AUTOMORPH_DATA
 
 def filter_frag(data_path):
     if os.path.isdir(data_path + 'raw/.ipynb_checkpoints'):
@@ -269,14 +277,30 @@ def get_args():
     parser.add_argument('--dataset', type=str, help='test dataset name', dest='dataset')
     parser.add_argument('--checkstart', type=int, help='test dataset name', dest='CS')
     parser.add_argument('--uniform', type=str, default='False', help='whether to uniform the image size', dest='uniform')
+    parser.add_argument(
+        '--image_folder',
+        type=str,
+        default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'images'),
+        help='Path to the folder containing input images',
+        dest='image_folder'
+    )
+    parser.add_argument(
+        '--result_folder',
+        type=str,
+        default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'Results'),
+        help='Path to the AutoMorph results folder',
+        dest='result_folder'
+    )
 
     return parser.parse_args()
 
 
 if __name__ == '__main__':
-    
+
     logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
     args = get_args()
+    AUTOMORPH_DATA, _ = prepare_automorph_data(args.image_folder, args.result_folder)
+    os.environ['AUTOMORPH_DATA'] = AUTOMORPH_DATA
     # Check if CUDA is available
     if torch.cuda.is_available():
         logging.info("CUDA is available. Using CUDA...")

--- a/M2_Artery_vein/test_outside.sh
+++ b/M2_Artery_vein/test_outside.sh
@@ -2,16 +2,33 @@
 
 export PYTHONPATH=.:$PYTHONPATH
 
+IMAGE_FOLDER=${1:-${AUTOMORPH_IMAGE_FOLDER}}
+RESULT_FOLDER=${2:-${AUTOMORPH_RESULT_FOLDER}}
+
 seed_number=42
 dataset_name='ALL-AV'
 test_checkpoint=1401
+
+if [ -z "${AUTOMORPH_DATA}" ]; then
+  AUTOMORPH_DATA=".."
+fi
+
+if [ -z "${IMAGE_FOLDER}" ]; then
+  IMAGE_FOLDER="${AUTOMORPH_DATA}/images"
+fi
+
+if [ -z "${RESULT_FOLDER}" ]; then
+  RESULT_FOLDER="${AUTOMORPH_DATA}/Results"
+fi
 
 date
 CUDA_VISIBLE_DEVICES=0 python test_outside.py --batch-size=8 \
                                                 --dataset=${dataset_name} \
                                                 --job_name=20210724_${dataset_name}_randomseed \
                                                 --checkstart=${test_checkpoint} \
-                                                --uniform=True
+                                                --uniform=True \
+                                                --image_folder="${IMAGE_FOLDER}" \
+                                                --result_folder="${RESULT_FOLDER}"
 
 
 date

--- a/M2_Vessel_seg/test_outside.sh
+++ b/M2_Vessel_seg/test_outside.sh
@@ -1,7 +1,18 @@
 #This is sh file for SEGAN
 
+IMAGE_FOLDER=${1:-${AUTOMORPH_IMAGE_FOLDER}}
+RESULT_FOLDER=${2:-${AUTOMORPH_RESULT_FOLDER}}
+
 if [ -z "${AUTOMORPH_DATA}" ]; then
   AUTOMORPH_DATA=".."
+fi
+
+if [ -z "${IMAGE_FOLDER}" ]; then
+  IMAGE_FOLDER="${AUTOMORPH_DATA}/images"
+fi
+
+if [ -z "${RESULT_FOLDER}" ]; then
+  RESULT_FOLDER="${AUTOMORPH_DATA}/Results"
 fi
 
 # define your job name
@@ -32,7 +43,9 @@ CUDA_VISIBLE_DEVICES=${gpu_id} python test_outside_integrated.py --epochs=1 \
                                                 --train_test_mode='test' \
                                                 --pre_threshold=40.0 \
                                                 --seed_num=${seed_number} \
-                                                --out_test="${AUTOMORPH_DATA}/Results/M2/binary_vessel/"
+                                                --out_test="${RESULT_FOLDER}/M2/binary_vessel/" \
+                                                --image_folder="${IMAGE_FOLDER}" \
+                                                --result_folder="${RESULT_FOLDER}"
                                                 
                                         
 

--- a/M2_Vessel_seg/test_outside_integrated.py
+++ b/M2_Vessel_seg/test_outside_integrated.py
@@ -16,8 +16,16 @@ from skimage.morphology import skeletonize,remove_small_objects
 from skimage import io
 from FD_cal import fractal_dimension,vessel_density
 import shutil
+from pathlib import Path
+import sys
 
-AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','..')
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from automorph_paths import prepare_automorph_data
+
+DEFAULT_AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA', '..')
+
+
+AUTOMORPH_DATA = DEFAULT_AUTOMORPH_DATA
 
 def filter_frag(data_path):
     if os.path.isdir(data_path + 'resize_binary/.ipynb_checkpoints'):
@@ -267,9 +275,23 @@ def get_args():
     parser.add_argument('--validation_ratio', type=float, default=10.0, help='Percent of the data that is used as validation 0-100', dest='val')
     parser.add_argument('--uniform', type=str, default='False', help='whether to uniform the image size', dest='uniform')
     parser.add_argument('--out_test', type=str, default='False', help='whether to uniform the image size', dest='data_path')
-    
+    parser.add_argument(
+        '--image_folder',
+        type=str,
+        default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'images'),
+        help='Path to the folder containing input images',
+        dest='image_folder'
+    )
+    parser.add_argument(
+        '--result_folder',
+        type=str,
+        default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'Results'),
+        help='Path to the AutoMorph results folder',
+        dest='result_folder'
+    )
+
     ####################### Loss weights ################################
-    
+
     parser.add_argument('--alpha', type=float, default=0.08, help='Loss weight of Adversarial Loss', dest='alpha')
     parser.add_argument('--beta', type=float, default=1.1, help='Loss weight of segmentation cross entropy', dest='beta')
     parser.add_argument('--gamma', type=float, default=0.5, help='Loss weight of segmentation mean square error', dest='gamma')
@@ -278,9 +300,11 @@ def get_args():
 
 
 if __name__ == '__main__':
-    
+
     logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
     args = get_args()
+    AUTOMORPH_DATA, _ = prepare_automorph_data(args.image_folder, args.result_folder)
+    os.environ['AUTOMORPH_DATA'] = AUTOMORPH_DATA
     # Check if CUDA is available
     if torch.cuda.is_available():
         logging.info("CUDA is available. Using CUDA...")

--- a/M2_lwnet_disc_cup/generate_av_results.py
+++ b/M2_lwnet_disc_cup/generate_av_results.py
@@ -17,8 +17,15 @@ from skimage import measure
 import pandas as pd
 from skimage.morphology import remove_small_objects
 import logging
+from pathlib import Path
 
-AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','..')
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from automorph_paths import prepare_automorph_data
+
+DEFAULT_AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA', '..')
+
+
+AUTOMORPH_DATA = DEFAULT_AUTOMORPH_DATA
 
 # argument parsing
 parser = argparse.ArgumentParser()
@@ -30,6 +37,10 @@ parser.add_argument('--config_file', type=str, default=None,
 parser.add_argument('--im_size', help='delimited list input, could be 600,400', type=str, default='512')
 parser.add_argument('--device', type=str, default='cuda:0', help='where to run the training code (e.g. "cpu" or "cuda:0") [default: %(default)s]')
 parser.add_argument('--results_path', type=str, default='results', help='path to save predictions (defaults to results')
+parser.add_argument('--image_folder', type=str, default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'images'),
+                    help='Path to the folder containing input images')
+parser.add_argument('--result_folder', type=str, default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'Results'),
+                    help='Path to the AutoMorph results folder')
 
 
 def intersection(mask,vessel_, it_x, it_y):
@@ -615,9 +626,11 @@ def prediction_eval(model_1,model_2,model_3,model_4,model_5,model_6,model_7,mode
 
 
 if __name__ == '__main__':
-    
+
     logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
     args = parser.parse_args()
+    AUTOMORPH_DATA, _ = prepare_automorph_data(args.image_folder, args.result_folder)
+    os.environ['AUTOMORPH_DATA'] = AUTOMORPH_DATA
     results_path = args.results_path
     # Check if CUDA is available
     if torch.cuda.is_available():

--- a/M2_lwnet_disc_cup/test_outside.sh
+++ b/M2_lwnet_disc_cup/test_outside.sh
@@ -1,6 +1,22 @@
 date
 
-python generate_av_results.py --config_file experiments/wnet_All_three_1024_disc_cup/30/config.cfg --im_size 512 --device cuda:0
+IMAGE_FOLDER=${1:-${AUTOMORPH_IMAGE_FOLDER}}
+RESULT_FOLDER=${2:-${AUTOMORPH_RESULT_FOLDER}}
+
+if [ -z "${AUTOMORPH_DATA}" ]; then
+  AUTOMORPH_DATA=".."
+fi
+
+if [ -z "${IMAGE_FOLDER}" ]; then
+  IMAGE_FOLDER="${AUTOMORPH_DATA}/images"
+fi
+
+if [ -z "${RESULT_FOLDER}" ]; then
+  RESULT_FOLDER="${AUTOMORPH_DATA}/Results"
+fi
+
+python generate_av_results.py --config_file experiments/wnet_All_three_1024_disc_cup/30/config.cfg --im_size 512 --device cuda:0 \
+  --image_folder="${IMAGE_FOLDER}" --result_folder="${RESULT_FOLDER}"
                            
 
 date

--- a/M3_feature_whole_pic/retipy/create_datasets_disc_centred.py
+++ b/M3_feature_whole_pic/retipy/create_datasets_disc_centred.py
@@ -26,27 +26,22 @@ import argparse
 import glob
 # import numpy as np
 import os
+import sys
 import h5py
 import shutil
 import pandas as pd
 # import scipy.stats as stats
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from automorph_paths import prepare_automorph_data
 
 from retipy import configuration, retina, tortuosity_measures
 
-AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','../..')
+DEFAULT_AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','../..')
 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/artery_binary_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/artery_binary_skeleton/.ipynb_checkpoints') 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/binary_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/binary_skeleton/.ipynb_checkpoints') 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/vein_binary_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/vein_binary_skeleton/.ipynb_checkpoints')
-if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Width/'):
-    os.makedirs(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Width/')
 
-# if os.path.exists('./DDR/av_seg/raw/.ipynb_checkpoints'):
-#    shutil.rmtree('./DDR/av_seg/raw/.ipynb_checkpoints') 
-
+AUTOMORPH_DATA = DEFAULT_AUTOMORPH_DATA
 
 parser = argparse.ArgumentParser()
 
@@ -55,7 +50,32 @@ parser.add_argument(
     "--configuration",
     help="the configuration file location",
     default="resources/retipy.config")
+parser.add_argument(
+    "--image_folder",
+    default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'images'),
+    help="Path to the folder containing input images"
+)
+parser.add_argument(
+    "--result_folder",
+    default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'Results'),
+    help="Path to the AutoMorph results folder"
+)
 args = parser.parse_args()
+
+AUTOMORPH_DATA, _ = prepare_automorph_data(args.image_folder, args.result_folder)
+
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/artery_binary_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/artery_binary_skeleton/.ipynb_checkpoints')
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/binary_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/binary_skeleton/.ipynb_checkpoints')
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/vein_binary_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/vein_binary_skeleton/.ipynb_checkpoints')
+if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Width/'):
+    os.makedirs(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Width/')
+
+# if os.path.exists('./DDR/av_seg/raw/.ipynb_checkpoints'):
+#    shutil.rmtree('./DDR/av_seg/raw/.ipynb_checkpoints')
+
 
 CONFIG = configuration.Configuration(args.configuration)
 binary_FD_binary,binary_VD_binary,binary_Average_width,binary_t2_list,binary_t4_list,binary_t5_list = [],[],[],[],[],[]

--- a/M3_feature_whole_pic/retipy/create_datasets_macular_centred.py
+++ b/M3_feature_whole_pic/retipy/create_datasets_macular_centred.py
@@ -26,27 +26,22 @@ import argparse
 import glob
 # import numpy as np
 import os
+import sys
 import h5py
 import shutil
 import pandas as pd
 # import scipy.stats as stats
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from automorph_paths import prepare_automorph_data
 
 from retipy import configuration, retina, tortuosity_measures
 
-AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','../..')
+DEFAULT_AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','../..')
 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/artery_binary_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/artery_binary_skeleton/.ipynb_checkpoints') 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/binary_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/binary_skeleton/.ipynb_checkpoints') 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/vein_binary_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/vein_binary_skeleton/.ipynb_checkpoints')
-if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Width/'):
-    os.makedirs(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Width/')
 
-#if os.path.exists('./DDR/av_seg/raw/.ipynb_checkpoints'):
-#    shutil.rmtree('./DDR/av_seg/raw/.ipynb_checkpoints') 
-
+AUTOMORPH_DATA = DEFAULT_AUTOMORPH_DATA
 
 parser = argparse.ArgumentParser()
 
@@ -55,7 +50,32 @@ parser.add_argument(
     "--configuration",
     help="the configuration file location",
     default="resources/retipy.config")
+parser.add_argument(
+    "--image_folder",
+    default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'images'),
+    help="Path to the folder containing input images"
+)
+parser.add_argument(
+    "--result_folder",
+    default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'Results'),
+    help="Path to the AutoMorph results folder"
+)
 args = parser.parse_args()
+
+AUTOMORPH_DATA, _ = prepare_automorph_data(args.image_folder, args.result_folder)
+
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/artery_binary_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/artery_binary_skeleton/.ipynb_checkpoints')
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/binary_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/binary_skeleton/.ipynb_checkpoints')
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/vein_binary_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/vein_binary_skeleton/.ipynb_checkpoints')
+if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Width/'):
+    os.makedirs(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Width/')
+
+#if os.path.exists('./DDR/av_seg/raw/.ipynb_checkpoints'):
+#    shutil.rmtree('./DDR/av_seg/raw/.ipynb_checkpoints')
+
 
 CONFIG = configuration.Configuration(args.configuration)
 binary_FD_binary,binary_VD_binary,binary_Average_width,binary_t2_list,binary_t4_list,binary_t5_list = [],[],[],[],[],[]

--- a/M3_feature_zone/retipy/create_datasets_disc_centred_B.py
+++ b/M3_feature_zone/retipy/create_datasets_disc_centred_B.py
@@ -26,27 +26,22 @@ import argparse
 import glob
 # import numpy as np
 import os
+import sys
 import h5py
 import shutil
 import pandas as pd
 # import scipy.stats as stats
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from automorph_paths import prepare_automorph_data
 
 from retipy import configuration, retina, tortuosity_measures
 
-AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','../..')
+DEFAULT_AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','../..')
 
 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_B_disc_centred_artery_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_B_disc_centred_artery_skeleton/.ipynb_checkpoints') 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/Zone_B_disc_centred_binary_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/Zone_B_disc_centred_binary_skeleton/.ipynb_checkpoints') 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_B_disc_centred_vein_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_B_disc_centred_vein_skeleton/.ipynb_checkpoints')
-if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Width/'):
-    os.makedirs(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Width/')
-
-#if os.path.exists('./DDR/av_seg/raw/.ipynb_checkpoints'):
-#    shutil.rmtree('./DDR/av_seg/raw/.ipynb_checkpoints') 
+AUTOMORPH_DATA = DEFAULT_AUTOMORPH_DATA
 
 
 parser = argparse.ArgumentParser()
@@ -56,7 +51,32 @@ parser.add_argument(
     "--configuration",
     help="the configuration file location",
     default="resources/retipy.config")
+parser.add_argument(
+    "--image_folder",
+    default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'images'),
+    help="Path to the folder containing input images"
+)
+parser.add_argument(
+    "--result_folder",
+    default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'Results'),
+    help="Path to the AutoMorph results folder"
+)
 args = parser.parse_args()
+
+
+AUTOMORPH_DATA, _ = prepare_automorph_data(args.image_folder, args.result_folder)
+
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_B_disc_centred_artery_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_B_disc_centred_artery_skeleton/.ipynb_checkpoints')
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/Zone_B_disc_centred_binary_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/Zone_B_disc_centred_binary_skeleton/.ipynb_checkpoints')
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_B_disc_centred_vein_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_B_disc_centred_vein_skeleton/.ipynb_checkpoints')
+if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Width/'):
+    os.makedirs(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Width/')
+
+#if os.path.exists('./DDR/av_seg/raw/.ipynb_checkpoints'):
+#    shutil.rmtree('./DDR/av_seg/raw/.ipynb_checkpoints')
 
 
 CONFIG = configuration.Configuration(args.configuration)

--- a/M3_feature_zone/retipy/create_datasets_disc_centred_C.py
+++ b/M3_feature_zone/retipy/create_datasets_disc_centred_C.py
@@ -26,26 +26,22 @@ import argparse
 import glob
 # import numpy as np
 import os
+import sys
 import h5py
 import shutil
 import pandas as pd
 # import scipy.stats as stats
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from automorph_paths import prepare_automorph_data
 
 from retipy import configuration, retina, tortuosity_measures
 
-AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','../..')
+DEFAULT_AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','../..')
 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_C_disc_centred_artery_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_C_disc_centred_artery_skeleton/.ipynb_checkpoints') 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/Zone_C_disc_centred_binary_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/Zone_C_disc_centred_binary_skeleton/.ipynb_checkpoints') 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_C_disc_centred_vein_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_C_disc_centred_vein_skeleton/.ipynb_checkpoints')
-if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Width/'):
-    os.makedirs(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Width/')
 
-#if os.path.exists('./DDR/av_seg/raw/.ipynb_checkpoints'):
-#    shutil.rmtree('./DDR/av_seg/raw/.ipynb_checkpoints') 
+AUTOMORPH_DATA = DEFAULT_AUTOMORPH_DATA
 
 
 parser = argparse.ArgumentParser()
@@ -55,7 +51,32 @@ parser.add_argument(
     "--configuration",
     help="the configuration file location",
     default="resources/retipy.config")
+parser.add_argument(
+    "--image_folder",
+    default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'images'),
+    help="Path to the folder containing input images"
+)
+parser.add_argument(
+    "--result_folder",
+    default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'Results'),
+    help="Path to the AutoMorph results folder"
+)
 args = parser.parse_args()
+
+
+AUTOMORPH_DATA, _ = prepare_automorph_data(args.image_folder, args.result_folder)
+
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_C_disc_centred_artery_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_C_disc_centred_artery_skeleton/.ipynb_checkpoints')
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/Zone_C_disc_centred_binary_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/Zone_C_disc_centred_binary_skeleton/.ipynb_checkpoints')
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_C_disc_centred_vein_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/Zone_C_disc_centred_vein_skeleton/.ipynb_checkpoints')
+if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Width/'):
+    os.makedirs(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Width/')
+
+#if os.path.exists('./DDR/av_seg/raw/.ipynb_checkpoints'):
+#    shutil.rmtree('./DDR/av_seg/raw/.ipynb_checkpoints')
 
 
 CONFIG = configuration.Configuration(args.configuration)

--- a/M3_feature_zone/retipy/create_datasets_macular_centred_B.py
+++ b/M3_feature_zone/retipy/create_datasets_macular_centred_B.py
@@ -26,26 +26,22 @@ import argparse
 import glob
 # import numpy as np
 import os
+import sys
 import h5py
 import shutil
 import pandas as pd
 # import scipy.stats as stats
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from automorph_paths import prepare_automorph_data
 
 from retipy import configuration, retina, tortuosity_measures
 
-AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','../..')
+DEFAULT_AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','../..')
 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/macular_Zone_B_centred_artery_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/macular_Zone_B_centred_artery_skeleton/.ipynb_checkpoints') 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/macular_Zone_B_centred_vein_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/macular_Zone_B_centred_vein_skeleton/.ipynb_checkpoints') 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/macular_Zone_B_centred_binary_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/macular_Zone_B_centred_binary_skeleton/.ipynb_checkpoints')
-if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Width/'):
-    os.makedirs(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Width/')
 
-#if os.path.exists('./DDR/av_seg/raw/.ipynb_checkpoints'):
-#    shutil.rmtree('./DDR/av_seg/raw/.ipynb_checkpoints') 
+AUTOMORPH_DATA = DEFAULT_AUTOMORPH_DATA
 
 
 parser = argparse.ArgumentParser()
@@ -55,7 +51,32 @@ parser.add_argument(
     "--configuration",
     help="the configuration file location",
     default="resources/retipy.config")
+parser.add_argument(
+    "--image_folder",
+    default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'images'),
+    help="Path to the folder containing input images"
+)
+parser.add_argument(
+    "--result_folder",
+    default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'Results'),
+    help="Path to the AutoMorph results folder"
+)
 args = parser.parse_args()
+
+AUTOMORPH_DATA, _ = prepare_automorph_data(args.image_folder, args.result_folder)
+
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/macular_Zone_B_centred_artery_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/macular_Zone_B_centred_artery_skeleton/.ipynb_checkpoints')
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/macular_Zone_B_centred_vein_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/macular_Zone_B_centred_vein_skeleton/.ipynb_checkpoints')
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/macular_Zone_B_centred_binary_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/macular_Zone_B_centred_binary_skeleton/.ipynb_checkpoints')
+if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Width/'):
+    os.makedirs(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Width/')
+
+#if os.path.exists('./DDR/av_seg/raw/.ipynb_checkpoints'):
+#    shutil.rmtree('./DDR/av_seg/raw/.ipynb_checkpoints')
+
 
 CONFIG = configuration.Configuration(args.configuration)
 binary_FD_binary,binary_VD_binary,binary_Average_width,binary_t2_list,binary_t4_list,binary_t5_list = [],[],[],[],[],[]

--- a/M3_feature_zone/retipy/create_datasets_macular_centred_C.py
+++ b/M3_feature_zone/retipy/create_datasets_macular_centred_C.py
@@ -26,25 +26,22 @@ import argparse
 import glob
 # import numpy as np
 import os
+import sys
 import h5py
 import shutil
 import pandas as pd
 # import scipy.stats as stats
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from automorph_paths import prepare_automorph_data
 
 from retipy import configuration, retina, tortuosity_measures
 
-AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','../..')
+DEFAULT_AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','../..')
 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/macular_Zone_C_centred_artery_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/macular_Zone_C_centred_artery_skeleton/.ipynb_checkpoints') 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/macular_Zone_C_centred_vein_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/macular_Zone_C_centred_vein_skeleton/.ipynb_checkpoints') 
-if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/macular_Zone_C_centred_binary_skeleton/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/macular_Zone_C_centred_binary_skeleton/.ipynb_checkpoints')
-if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Width/'):
-    os.makedirs(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Width/')
-#if os.path.exists('./DDR/av_seg/raw/.ipynb_checkpoints'):
-#    shutil.rmtree('./DDR/av_seg/raw/.ipynb_checkpoints') 
+
+AUTOMORPH_DATA = DEFAULT_AUTOMORPH_DATA
 
 
 parser = argparse.ArgumentParser()
@@ -54,7 +51,31 @@ parser.add_argument(
     "--configuration",
     help="the configuration file location",
     default="resources/retipy.config")
+parser.add_argument(
+    "--image_folder",
+    default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'images'),
+    help="Path to the folder containing input images"
+)
+parser.add_argument(
+    "--result_folder",
+    default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'Results'),
+    help="Path to the AutoMorph results folder"
+)
 args = parser.parse_args()
+
+AUTOMORPH_DATA, _ = prepare_automorph_data(args.image_folder, args.result_folder)
+
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/macular_Zone_C_centred_artery_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/macular_Zone_C_centred_artery_skeleton/.ipynb_checkpoints')
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/macular_Zone_C_centred_vein_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/binary_vessel/macular_Zone_C_centred_vein_skeleton/.ipynb_checkpoints')
+if os.path.exists(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/macular_Zone_C_centred_binary_skeleton/.ipynb_checkpoints'):
+    shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M2/artery_vein/macular_Zone_C_centred_binary_skeleton/.ipynb_checkpoints')
+if not os.path.exists(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Width/'):
+    os.makedirs(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Width/')
+#if os.path.exists('./DDR/av_seg/raw/.ipynb_checkpoints'):
+#    shutil.rmtree('./DDR/av_seg/raw/.ipynb_checkpoints')
+
 
 CONFIG = configuration.Configuration(args.configuration)
 binary_FD_binary,binary_VD_binary,binary_Average_width,binary_t2_list,binary_t4_list,binary_t5_list = [],[],[],[],[],[]

--- a/README.md
+++ b/README.md
@@ -44,6 +44,22 @@ Use the Google Colab and a free Tesla T4 gpu [Colab link click](https://colab.re
 
 Install and use on your own machines [LOCAL.md](LOCAL.md).
 
+#### `run.sh` quick start (custom paths)
+
+The pipeline entrypoint accepts optional flags for the image source and output
+directories. After preparing your Python environment as documented in
+`LOCAL.md`, run:
+
+```bash
+sh run.sh --image_folder=/absolute/path/to/images --result_folder=/absolute/path/to/results
+```
+
+Both arguments also work with relative paths. When you omit them the script
+falls back to `./images` and `./Results`, or `${AUTOMORPH_DATA}/images` and
+`${AUTOMORPH_DATA}/Results` if you have the `AUTOMORPH_DATA` environment
+variable defined. Add `--help` to see every available toggle (including the
+stage-specific `--no_*` switches).
+
 
 ### Running with Docker
 

--- a/automorph_paths.py
+++ b/automorph_paths.py
@@ -1,0 +1,125 @@
+"""Utilities for preparing AutoMorph input/output directories."""
+from __future__ import annotations
+
+import atexit
+import csv
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Optional, Tuple
+
+DEFAULT_PIXEL_RESOLUTION = 0.008
+
+
+def _coerce_float(value: Optional[str]) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _write_resolution_file(destination: Path, image_path: Path, pixel_resolution: float) -> Path:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    images = [entry.name for entry in sorted(image_path.iterdir()) if entry.is_file()]
+    with destination.open('w', newline='', encoding='utf-8') as csv_file:
+        writer = csv.writer(csv_file)
+        writer.writerow(['fundus', 'res'])
+        for name in images:
+            writer.writerow([name, pixel_resolution])
+    return destination
+
+
+def _resolve_resolution_source(
+    provided_resolution: Optional[str], image_path: Path, result_path: Path
+) -> Optional[Path]:
+    candidates = []
+    if provided_resolution:
+        candidates.append(Path(provided_resolution).expanduser())
+    candidates.extend(
+        [
+            image_path / 'resolution_information.csv',
+            result_path / 'resolution_information.csv',
+            image_path.parent / 'resolution_information.csv',
+            result_path.parent / 'resolution_information.csv',
+        ]
+    )
+
+    for candidate in candidates:
+        try:
+            candidate_resolved = candidate.resolve(strict=True)
+        except FileNotFoundError:
+            continue
+        if candidate_resolved.is_file():
+            return candidate_resolved
+    return None
+
+
+def _ensure_resolution_file(
+    destination: Path, image_path: Path, result_path: Path, provided_resolution: Optional[str]
+) -> Path:
+    destination = destination.expanduser()
+    if destination.exists() and destination.is_file():
+        return destination
+
+    source = _resolve_resolution_source(provided_resolution, image_path, result_path)
+    if source:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if destination.resolve() == source:
+            return destination
+        shutil.copyfile(source, destination)
+        return destination
+
+    pixel_resolution = _coerce_float(os.getenv('AUTOMORPH_PIXEL_RESOLUTION'))
+    if pixel_resolution is None:
+        pixel_resolution = DEFAULT_PIXEL_RESOLUTION
+    return _write_resolution_file(destination, image_path, pixel_resolution)
+
+
+def prepare_automorph_data(
+    image_folder: str, result_folder: str, resolution_file: Optional[str] = None
+) -> Tuple[str, str]:
+    """Prepare AutoMorph runtime directories.
+
+    Returns a tuple with the AutoMorph base directory and the path to
+    ``resolution_information.csv`` within that directory.
+    """
+
+    image_path = Path(image_folder).expanduser().resolve()
+    result_path = Path(result_folder).expanduser().resolve()
+
+    image_path.mkdir(parents=True, exist_ok=True)
+    result_path.mkdir(parents=True, exist_ok=True)
+
+    provided_resolution = resolution_file or os.getenv('AUTOMORPH_RESOLUTION_FILE')
+
+    if (
+        image_path.name.lower() == 'images'
+        and result_path.name.lower() == 'results'
+        and image_path.parent == result_path.parent
+    ):
+        base_path = image_path.parent
+        resolution_path = _ensure_resolution_file(
+            base_path / 'resolution_information.csv', image_path, result_path, provided_resolution
+        )
+    else:
+        temp_dir = Path(tempfile.mkdtemp(prefix='automorph_data_'))
+        atexit.register(shutil.rmtree, temp_dir, ignore_errors=True)
+
+        images_link = temp_dir / 'images'
+        results_link = temp_dir / 'Results'
+        if not images_link.exists():
+            images_link.symlink_to(image_path, target_is_directory=True)
+        if not results_link.exists():
+            results_link.symlink_to(result_path, target_is_directory=True)
+
+        resolution_path = _ensure_resolution_file(
+            temp_dir / 'resolution_information.csv', image_path, result_path, provided_resolution
+        )
+        base_path = temp_dir
+
+    os.environ['AUTOMORPH_DATA'] = str(base_path)
+    os.environ['AUTOMORPH_RESOLUTION_FILE'] = str(resolution_path)
+    return str(base_path), str(resolution_path)

--- a/csv_merge.py
+++ b/csv_merge.py
@@ -1,40 +1,67 @@
 import shutil
 import os
+import sys
 import pandas as pd
+from argparse import ArgumentParser
+from pathlib import Path
 
-AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','.')
+sys.path.append(str(Path(__file__).resolve().parent))
+from automorph_paths import prepare_automorph_data
 
-# merge all csvs
-Disc_whole_image = pd.read_csv(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Disc_Measurement.csv')
-Disc_zone_b = pd.read_csv(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Disc_Zone_B_Measurement.csv')
-Disc_zone_c = pd.read_csv(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/Disc_Zone_C_Measurement.csv')
+DEFAULT_AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','.')
 
-Macular_whole_image = pd.read_csv(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Macular_Measurement.csv')
-Macular_zone_b = pd.read_csv(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Macular_Zone_B_Measurement.csv')
-Macular_zone_c = pd.read_csv(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/Macular_Zone_C_Measurement.csv')
 
-Disc_zone = Disc_zone_b.merge(Disc_zone_c, how = 'outer', on = ['Name', 'Disc_height', 'Disc_width', 'Cup_height', 'Cup_width', \
+def main():
+    parser = ArgumentParser(description='Merge AutoMorph CSV outputs')
+    parser.add_argument(
+        '--image_folder',
+        default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'images'),
+        help='Path to the folder containing input images'
+    )
+    parser.add_argument(
+        '--result_folder',
+        default=str(Path(DEFAULT_AUTOMORPH_DATA) / 'Results'),
+        help='Path to the AutoMorph results folder'
+    )
+    args = parser.parse_args()
+
+    automorph_base, _ = prepare_automorph_data(args.image_folder, args.result_folder)
+
+    # merge all csvs
+    Disc_whole_image = pd.read_csv(f'{automorph_base}/Results/M3/Disc_centred/Disc_Measurement.csv')
+    Disc_zone_b = pd.read_csv(f'{automorph_base}/Results/M3/Disc_centred/Disc_Zone_B_Measurement.csv')
+    Disc_zone_c = pd.read_csv(f'{automorph_base}/Results/M3/Disc_centred/Disc_Zone_C_Measurement.csv')
+
+    Macular_whole_image = pd.read_csv(f'{automorph_base}/Results/M3/Macular_centred/Macular_Measurement.csv')
+    Macular_zone_b = pd.read_csv(f'{automorph_base}/Results/M3/Macular_centred/Macular_Zone_B_Measurement.csv')
+    Macular_zone_c = pd.read_csv(f'{automorph_base}/Results/M3/Macular_centred/Macular_Zone_C_Measurement.csv')
+
+    Disc_zone = Disc_zone_b.merge(Disc_zone_c, how='outer', on=['Name', 'Disc_height', 'Disc_width', 'Cup_height', 'Cup_width',
                                                                 'CDR_vertical', 'CDR_horizontal'], suffixes=('_zone_b', '_zone_c'))
 
-Disc_all = Disc_whole_image.merge(Disc_zone, how = 'outer', on = ['Name', 'Disc_height', 'Disc_width', 'Cup_height', 'Cup_width', \
-                                                                'CDR_vertical', 'CDR_horizontal'])
+    Disc_all = Disc_whole_image.merge(Disc_zone, how='outer', on=['Name', 'Disc_height', 'Disc_width', 'Cup_height', 'Cup_width',
+                                                                  'CDR_vertical', 'CDR_horizontal'])
 
 
-Macular_zone = Macular_zone_b.merge(Macular_zone_c, how = 'outer', on = ['Name', 'Disc_height', 'Disc_width', 'Cup_height', 'Cup_width', \
+    Macular_zone = Macular_zone_b.merge(Macular_zone_c, how='outer', on=['Name', 'Disc_height', 'Disc_width', 'Cup_height', 'Cup_width',
                                                                          'CDR_vertical', 'CDR_horizontal'], suffixes=('_zone_b', '_zone_c'))
 
-Macular_all = Macular_whole_image.merge(Macular_zone, how = 'outer', on = ['Name', 'Disc_height', 'Disc_width', 'Cup_height', 'Cup_width', \
-                                                                         'CDR_vertical', 'CDR_horizontal'])
+    Macular_all = Macular_whole_image.merge(Macular_zone, how='outer', on=['Name', 'Disc_height', 'Disc_width', 'Cup_height', 'Cup_width',
+                                                                           'CDR_vertical', 'CDR_horizontal'])
 
 
-# replace all -1 with empty string
-Disc_all.replace(-1, "", inplace=True)
-Macular_all.replace(-1, "", inplace=True)
+    # replace all -1 with empty string
+    Disc_all.replace(-1, "", inplace=True)
+    Macular_all.replace(-1, "", inplace=True)
 
-Disc_all.to_csv(f'{AUTOMORPH_DATA}/Results/M3/Disc_Features.csv', index=False)
-Macular_all.to_csv(f'{AUTOMORPH_DATA}/Results/M3/Macular_Features.csv', index=False)
+    Disc_all.to_csv(f'{automorph_base}/Results/M3/Disc_Features.csv', index=False)
+    Macular_all.to_csv(f'{automorph_base}/Results/M3/Macular_Features.csv', index=False)
 
-# remove the sub csvs
-shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M3/Disc_centred/')
-shutil.rmtree(f'{AUTOMORPH_DATA}/Results/M3/Macular_centred/')
+    # remove the sub csvs
+    shutil.rmtree(f'{automorph_base}/Results/M3/Disc_centred/')
+    shutil.rmtree(f'{automorph_base}/Results/M3/Macular_centred/')
+
+
+if __name__ == '__main__':
+    main()
 

--- a/generate_resolution.py
+++ b/generate_resolution.py
@@ -1,24 +1,49 @@
-import pandas as pd
+import argparse
 import os
-import sys
-import shutil
+from pathlib import Path
+import pandas as pd
 
-AUTOMORPH_DATA = os.getenv('AUTOMORPH_DATA','.')
+DEFAULT_PIXEL_RESOLUTION = 0.008
 
-# read pixel_resolution from cli arg if defined, otherwise use default value 0.008
-pixel_resolution = float(sys.argv[1]) if len(sys.argv) > 1 else 0.008
 
-if os.path.exists(f'{AUTOMORPH_DATA}/images/.ipynb_checkpoints'):
-    shutil.rmtree(f'{AUTOMORPH_DATA}/images/.ipynb_checkpoints')
+def build_dataframe(image_folder: Path, pixel_resolution: float) -> pd.DataFrame:
+    images = [entry.name for entry in sorted(image_folder.iterdir()) if entry.is_file()]
+    return pd.DataFrame({'fundus': images, 'res': [pixel_resolution] * len(images)})
 
-image_list = sorted(os.listdir(f'{AUTOMORPH_DATA}/images/'))
-img_list = []
-# import image resolution here
-res_list = []
 
-for i in image_list:
-    img_list.append(i)
-    res_list.append(pixel_resolution)
-    
-Data4stage2 = pd.DataFrame({'fundus':img_list, 'res':res_list})
-Data4stage2.to_csv(f'{AUTOMORPH_DATA}/resolution_information.csv', index = None, encoding='utf8')
+def main() -> str:
+    parser = argparse.ArgumentParser(description='Generate resolution_information.csv for AutoMorph runs.')
+    parser.add_argument('--image_folder', required=True, help='Folder containing input images.')
+    parser.add_argument('--result_folder', help='Folder where pipeline results are stored.')
+    parser.add_argument('--output', help='Explicit path where resolution_information.csv should be written.')
+    parser.add_argument('--pixel_resolution', type=float, default=None, help='Pixel resolution value to use for all images.')
+    args = parser.parse_args()
+
+    image_path = Path(args.image_folder).expanduser().resolve()
+    if not image_path.exists():
+        raise FileNotFoundError(f'Image folder {image_path} does not exist')
+
+    result_path = Path(args.result_folder).expanduser().resolve() if args.result_folder else None
+
+    if args.output:
+        output_path = Path(args.output).expanduser().resolve()
+    elif result_path is not None:
+        output_path = result_path / 'resolution_information.csv'
+    else:
+        output_path = image_path.parent / 'resolution_information.csv'
+
+    pixel_resolution = args.pixel_resolution
+    if pixel_resolution is None:
+        pixel_resolution = os.getenv('AUTOMORPH_PIXEL_RESOLUTION')
+        pixel_resolution = float(pixel_resolution) if pixel_resolution else DEFAULT_PIXEL_RESOLUTION
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    df = build_dataframe(image_path, pixel_resolution)
+    df.to_csv(output_path, index=False, encoding='utf8')
+
+    print(str(output_path))
+    return str(output_path)
+
+
+if __name__ == '__main__':
+    main()

--- a/run.sh
+++ b/run.sh
@@ -12,9 +12,34 @@ NO_PROCESS=0
 NO_QUALITY=0
 NO_SEGMENTATION=0
 NO_FEATURE=0
+IMAGE_FOLDER=""
+RESULT_FOLDER=""
+
+usage() {
+  cat <<'EOF'
+Usage: sh run.sh [options]
+
+Options:
+  --image_folder=PATH   Absolute or relative path to the folder containing input images.
+  --result_folder=PATH  Absolute or relative path where pipeline outputs should be written.
+  --no_process          Skip the preprocessing stage.
+  --no_quality          Skip the image quality assessment stage.
+  --no_segmentation     Skip the vessel/artery-vein/optic-disc segmentation stage.
+  --no_feature          Skip feature extraction and CSV merging.
+  -h, --help            Show this help message and exit.
+
+If paths are omitted, the script falls back to ./images and ./Results, or
+${AUTOMORPH_DATA}/images and ${AUTOMORPH_DATA}/Results when the environment
+variable AUTOMORPH_DATA is set.
+EOF
+}
 
 for arg in "$@"; do
   case $arg in
+    -h|--help)
+      usage
+      exit 0
+      ;;
     --no_process)
       NO_PROCESS=1
       shift
@@ -31,8 +56,38 @@ for arg in "$@"; do
       NO_FEATURE=1
       shift
       ;;
+    --image_folder=*)
+      IMAGE_FOLDER="${arg#*=}"
+      shift
+      ;;
+    --result_folder=*)
+      RESULT_FOLDER="${arg#*=}"
+      shift
+      ;;
   esac
 done
+
+# Default paths if not provided
+if [ -z "$IMAGE_FOLDER" ]; then
+  if [ -n "${AUTOMORPH_DATA}" ]; then
+    IMAGE_FOLDER="${AUTOMORPH_DATA}/images"
+  else
+    IMAGE_FOLDER="./images"
+  fi
+fi
+
+if [ -z "$RESULT_FOLDER" ]; then
+  if [ -n "${AUTOMORPH_DATA}" ]; then
+    RESULT_FOLDER="${AUTOMORPH_DATA}/Results"
+  else
+    RESULT_FOLDER="./Results"
+  fi
+fi
+
+echo "Using image folder: ${IMAGE_FOLDER}"
+echo "Using result folder: ${RESULT_FOLDER}"
+
+export PYTHONPATH="$(pwd):${PYTHONPATH}"
 
 # ----------------------------- #
 # Step 0 - Prepare AUTOMORPH_DATA directory and clean up results
@@ -40,13 +95,13 @@ done
 
 python automorph_data.py
 
-if [ -z "${AUTOMORPH_DATA}" ]; then
-  rm -rf ./Results/*
-  echo "AUTOMORPH_DATA not set, using default directory"
-else
-  rm -rf "${AUTOMORPH_DATA}/Results"/*
-  echo "AUTOMORPH_DATA set to ${AUTOMORPH_DATA}"
-fi
+mkdir -p "${RESULT_FOLDER}"
+rm -rf "${RESULT_FOLDER}"/*
+
+mkdir -p "${IMAGE_FOLDER}"
+
+RESOLUTION_FILE=$(python generate_resolution.py --image_folder "${IMAGE_FOLDER}" --result_folder "${RESULT_FOLDER}")
+export AUTOMORPH_RESOLUTION_FILE="${RESOLUTION_FILE}"
 
 # ----------------------------- #
 # Step 1 - Image Preprocessing
@@ -54,7 +109,7 @@ fi
 if [ $NO_PROCESS -eq 0 ]; then
   echo "### Preprocess Start ###"
   cd M0_Preprocess
-  python EyeQ_process_main.py
+  python EyeQ_process_main.py --image_folder "${IMAGE_FOLDER}" --result_folder "${RESULT_FOLDER}"
   cd ..
 else
   echo "### Skipping Preprocessing ###"
@@ -66,8 +121,8 @@ fi
 if [ $NO_QUALITY -eq 0 ]; then
   echo "### Image Quality Assessment ###"
   cd M1_Retinal_Image_quality_EyePACS
-  sh test_outside.sh
-  python merge_quality_assessment.py
+  sh test_outside.sh "${IMAGE_FOLDER}" "${RESULT_FOLDER}"
+  python merge_quality_assessment.py --image_folder "${IMAGE_FOLDER}" --result_folder "${RESULT_FOLDER}"
   cd ..
 else
   echo "### Skipping Image Quality Assessment ###"
@@ -78,17 +133,17 @@ fi
 # ----------------------------- #
 if [ $NO_SEGMENTATION -eq 0 ]; then
   echo "### Segmentation Modules ###"
-  
+
   cd M2_Vessel_seg
-  sh test_outside.sh
+  sh test_outside.sh "${IMAGE_FOLDER}" "${RESULT_FOLDER}"
   cd ..
 
   cd M2_Artery_vein
-  sh test_outside.sh
+  sh test_outside.sh "${IMAGE_FOLDER}" "${RESULT_FOLDER}"
   cd ..
 
   cd M2_lwnet_disc_cup
-  sh test_outside.sh
+  sh test_outside.sh "${IMAGE_FOLDER}" "${RESULT_FOLDER}"
   cd ..
 else
   echo "### Skipping Segmentation Modules ###"
@@ -101,18 +156,18 @@ if [ $NO_FEATURE -eq 0 ]; then
   echo "### Feature Measuring ###"
 
   cd M3_feature_zone/retipy/
-  python create_datasets_disc_centred_B.py
-  python create_datasets_disc_centred_C.py
-  python create_datasets_macular_centred_B.py
-  python create_datasets_macular_centred_C.py
+  python create_datasets_disc_centred_B.py --image_folder "${IMAGE_FOLDER}" --result_folder "${RESULT_FOLDER}"
+  python create_datasets_disc_centred_C.py --image_folder "${IMAGE_FOLDER}" --result_folder "${RESULT_FOLDER}"
+  python create_datasets_macular_centred_B.py --image_folder "${IMAGE_FOLDER}" --result_folder "${RESULT_FOLDER}"
+  python create_datasets_macular_centred_C.py --image_folder "${IMAGE_FOLDER}" --result_folder "${RESULT_FOLDER}"
   cd ../..
 
   cd M3_feature_whole_pic/retipy/
-  python create_datasets_macular_centred.py
-  python create_datasets_disc_centred.py
+  python create_datasets_macular_centred.py --image_folder "${IMAGE_FOLDER}" --result_folder "${RESULT_FOLDER}"
+  python create_datasets_disc_centred.py --image_folder "${IMAGE_FOLDER}" --result_folder "${RESULT_FOLDER}"
   cd ../..
 
-  python csv_merge.py
+  python csv_merge.py --image_folder "${IMAGE_FOLDER}" --result_folder "${RESULT_FOLDER}"
 else
   echo "### Skipping Feature Measurement ###"
 fi


### PR DESCRIPTION
## Summary
- add a shared helper that normalises image/result directories and ensures a matching `resolution_information.csv` is present for each run
- extend `generate_resolution.py` and `run.sh` so the resolution CSV is generated from the provided folders and its location is exported to downstream stages
- update preprocessing, quality, segmentation, and feature scripts to reuse the helper and honour the forwarded resolution file

## Testing
- `python -m compileall automorph_paths.py generate_resolution.py M0_Preprocess/EyeQ_process_main.py M1_Retinal_Image_quality_EyePACS/test_outside.py M1_Retinal_Image_quality_EyePACS/merge_quality_assessment.py M2_Vessel_seg/test_outside_integrated.py M2_Artery_vein/test_outside.py M2_lwnet_disc_cup/generate_av_results.py M3_feature_zone/retipy/create_datasets_disc_centred_B.py M3_feature_zone/retipy/create_datasets_disc_centred_C.py M3_feature_zone/retipy/create_datasets_macular_centred_B.py M3_feature_zone/retipy/create_datasets_macular_centred_C.py M3_feature_whole_pic/retipy/create_datasets_disc_centred.py M3_feature_whole_pic/retipy/create_datasets_macular_centred.py csv_merge.py`


------
https://chatgpt.com/codex/tasks/task_e_68e63a2e4e248330b0432a8fe40cba0d